### PR TITLE
Added LinearAlgebra and Test to dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,12 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ChainRulesCore = "0.5, 0.6"

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -4,6 +4,7 @@ using ChainRulesCore
 using ChainRulesCore: frule, rrule
 using ChainRulesCore: AbstractDifferential
 using FiniteDifferences
+using LinearAlgebra
 using Test
 
 const _fdm = central_fdm(5, 1)


### PR DESCRIPTION
I'm in the process of updating [ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl/) to use this package for testing. While updating it I am running into a couple of warnings and errors:

1) `ChainRulesTestUtils` does not have Test in its dependencies
```
┌ Warning: Package ChainRulesTestUtils does not have Test in its dependencies:
│ - If you have ChainRulesTestUtils checked out for development and have
│   added Test as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with ChainRulesTestUtils
└ Loading Test into ChainRulesTestUtils from project dependency, future warnings for ChainRulesTestUtils are suppressed.
```

2) `I` is not defined
```
 Error During Test at /Users/mattbr/.julia/dev/ChainRules.jl/test/rulesets/LinearAlgebra/factorization.jl:58
  Got exception outside of a @test
  UndefVarError: I not defined
  Stacktrace:
   [1] generate_well_conditioned_matrix(::MersenneTwister, ::Int64) at /Users/mattbr/.julia/packages/ChainRulesTestUtils/ulh9b/src/ChainRulesTestUtils.jl:46
```