### PR TITLE
Add docstring for `_make_fdm_call`

### DIFF
--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -14,6 +14,22 @@ export test_scalar, frule_test, rrule_test, isapprox, generate_well_conditioned_
 Base.isapprox(d_ad::DoesNotExist, d_fd; kwargs...) = error("Tried to differentiate w.r.t. a `DoesNotExist`")
 Base.isapprox(d_ad::AbstractDifferential, d_fd; kwargs...) = isapprox(extern(d_ad), d_fd; kwargs...)
 
+"""
+    _make_fdm_call(fdm, f, ȳ, xs, ignores) -> Tuple
+
+Call `FiniteDifferences.j′vp`, with the option to ignore certain `xs`.
+
+# Arguments
+- `fdm::FiniteDifferenceMethod`: How to numerically differentiate `f`.
+- `f`: The function to differentiate.
+- `ȳ`: adjoint w.r.t. output of `f`.
+- `xs`: Inputs to `f`, such that `y = f(xs...)`.
+- `ignores`: Collection of `Bool`s, the same length as `xs`.
+  If `ignores[i] === true`, then `xs[i]` is ignored; `∂f_∂xs[i] === nothing`.
+
+# Returns
+- `∂f_∂xs::Tuple`: Derivatives estimated by finite differencing.
+"""
 function _make_fdm_call(fdm, f, ȳ, xs, ignores)
     sig = Expr(:tuple)
     call = Expr(:call, f)

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -25,10 +25,10 @@ Call `FiniteDifferences.j′vp`, with the option to ignore certain `xs`.
 - `ȳ`: adjoint w.r.t. output of `f`.
 - `xs`: Inputs to `f`, such that `y = f(xs...)`.
 - `ignores`: Collection of `Bool`s, the same length as `xs`.
-  If `ignores[i] === true`, then `xs[i]` is ignored; `∂f_∂xs[i] === nothing`.
+  If `ignores[i] === true`, then `xs[i]` is ignored; `∂xs[i] === nothing`.
 
 # Returns
-- `∂f_∂xs::Tuple`: Derivatives estimated by finite differencing.
+- `∂xs::Tuple`: Derivatives estimated by finite differencing.
 """
 function _make_fdm_call(fdm, f, ȳ, xs, ignores)
     sig = Expr(:tuple)


### PR DESCRIPTION
- Explain that this is basically just `FiniteDifferences.j'vp`
- Doesn't go as far as to justify having it, or why it's written so sneakily 😂  