### PR TITLE
Generate well conditioned matrix using Random.GLOBAL_RNG

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/data_generation.jl
+++ b/src/data_generation.jl
@@ -4,3 +4,4 @@ function generate_well_conditioned_matrix(rng, N)
     return A * A' + I
 end
 
+generate_well_conditioned_matrix(N) = generate_well_conditioned_matrix(Random.GLOBAL_RNG, N)


### PR DESCRIPTION
<s>We need to remove the random number generation parameter in the generate_well_conditioned_matrix` function to be able to continue with https://github.com/JuliaDiff/ChainRules.jl/issues/180</s>

Create a secondary definition for `generate_well_conditioned_matrix()`