### PR TITLE
UndefVarError Random not defined in data_generation.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,9 +15,3 @@ ChainRulesCore = "0.7.1"
 Compat = "3"
 FiniteDifferences = "0.9"
 julia = "1"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
@@ -16,8 +17,7 @@ FiniteDifferences = "0.9"
 julia = "1"
 
 [extras]
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Random", "Test"]
+test = ["Test"]

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -6,6 +6,7 @@ using Compat: only
 using FiniteDifferences
 using FiniteDifferences: to_vec
 using LinearAlgebra
+using Random
 using Test
 
 const _fdm = central_fdm(5, 1)

--- a/src/data_generation.jl
+++ b/src/data_generation.jl
@@ -1,5 +1,3 @@
-using Random
-
 # Useful for LinearAlgebra tests
 function generate_well_conditioned_matrix(rng, N)
     A = randn(rng, N, N)

--- a/src/data_generation.jl
+++ b/src/data_generation.jl
@@ -1,3 +1,5 @@
+using Random
+
 # Useful for LinearAlgebra tests
 function generate_well_conditioned_matrix(rng, N)
     A = randn(rng, N, N)

--- a/test/data_generation.jl
+++ b/test/data_generation.jl
@@ -1,0 +1,14 @@
+@testset "Data Generation" begin
+    @testset "Generate Well Conditioned Matrix - RNG" begin
+        rng = MersenneTwister(1)
+        matrix = generate_well_conditioned_matrix(rng, 5)
+
+        @test isempty(matrix) == false
+    end
+
+    @testset "Generate Well Conditioned Matrix - Global RNG" begin
+        matrix = generate_well_conditioned_matrix(5)
+
+        @test isempty(matrix) == false
+    end
+end

--- a/test/data_generation.jl
+++ b/test/data_generation.jl
@@ -1,5 +1,5 @@
 @testset "Data Generation" begin
-    function _is_well_conditioned(matrix::Array{Float64})
+    function _is_well_conditioned(matrix)
         @test !isempty(matrix)
         @test isposdef(matrix)
         @assert length(matrix) ≤ 25  

--- a/test/data_generation.jl
+++ b/test/data_generation.jl
@@ -1,14 +1,18 @@
 @testset "Data Generation" begin
-    @testset "Generate Well Conditioned Matrix - RNG" begin
-        rng = MersenneTwister(1)
-        matrix = generate_well_conditioned_matrix(rng, 5)
+    @testset "Generate Well Conditioned Matrix" begin
+        @testset "Pass in RNG" begin
+            rng = MersenneTwister(1)
+            matrix = generate_well_conditioned_matrix(rng, 5)
 
-        @test isempty(matrix) == false
-    end
+            @test !isempty(matrix)
+            @test isposdef(matrix)
+        end
 
-    @testset "Generate Well Conditioned Matrix - Global RNG" begin
-        matrix = generate_well_conditioned_matrix(5)
+        @testset "Global RNG" begin
+            matrix = generate_well_conditioned_matrix(5)
 
-        @test isempty(matrix) == false
+            @test !isempty(matrix)
+            @test isposdef(matrix)
+        end
     end
 end

--- a/test/data_generation.jl
+++ b/test/data_generation.jl
@@ -1,18 +1,23 @@
 @testset "Data Generation" begin
+    function _is_well_conditioned(matrix::Array{Float64})
+        @test !isempty(matrix)
+        @test isposdef(matrix)
+        @test cond(matrix) < 20
+    end
+
+
     @testset "Generate Well Conditioned Matrix" begin
         @testset "Pass in RNG" begin
             rng = MersenneTwister(1)
             matrix = generate_well_conditioned_matrix(rng, 5)
 
-            @test !isempty(matrix)
-            @test isposdef(matrix)
+            _is_well_conditioned(matrix)
         end
 
         @testset "Global RNG" begin
             matrix = generate_well_conditioned_matrix(5)
 
-            @test !isempty(matrix)
-            @test isposdef(matrix)
+            _is_well_conditioned(matrix)
         end
     end
 end

--- a/test/data_generation.jl
+++ b/test/data_generation.jl
@@ -2,6 +2,7 @@
     function _is_well_conditioned(matrix::Array{Float64})
         @test !isempty(matrix)
         @test isposdef(matrix)
+        @assert length(matrix) ≤ 25  
         @test cond(matrix) < 20
     end
 

--- a/test/data_generation.jl
+++ b/test/data_generation.jl
@@ -3,7 +3,7 @@
         @test !isempty(matrix)
         @test isposdef(matrix)
         @assert length(matrix) ≤ 25  
-        @test cond(matrix) < 20
+        @test cond(matrix) < 100
     end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,4 +7,5 @@ using Test
     include("to_vec.jl")
     include("isapprox.jl")
     include("testers.jl")
+    include("data_generation.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using ChainRulesCore
 using ChainRulesTestUtils
+using LinearAlgebra
 using Random
 using Test
 


### PR DESCRIPTION
```
 UndefVarError: Random not defined
  Stacktrace:
   [1] generate_well_conditioned_matrix(::Int64) at /Users/mattbr/.julia/packages/ChainRulesTestUtils/pVYVF/src/data_generation.jl:7
```

We don't have any tests for `data_generation.jl`, in `0.2.3` I added in a secondary function for `generate_well_conditioned_matrix(N)` which used the `GLOBAL_RNG` from `Random`. It was not defined in this source file and would error out.

I added in some tests for a pre-defined rng and the global one and made the changes so that this code would work.