### PR TITLE
Remove eval called by rrule_test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -51,6 +51,7 @@ function _make_fdm_call(fdm, f, ȳ, xs, ignores)
     sigargs = xs[.!ignores]
     arginds = (1:length(xs))[.!ignores]
     fd = j′vp(fdm, f2, ȳ, sigargs...)
+    @assert length(fd) == length(arginds)
 
     for (dx, ind) in zip(fd, arginds)
         args[ind] = dx

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -32,6 +32,7 @@ function _make_fdm_call(fdm, f, ȳ, xs, ignores)
     function f2(sigargs...)
         callargs = Any[]
         j = 1
+
         for (i, (x, ignore)) in enumerate(zip(xs, ignores))
             if ignore
                 push!(callargs, x)
@@ -50,6 +51,7 @@ function _make_fdm_call(fdm, f, ȳ, xs, ignores)
     sigargs = xs[.!ignores]
     arginds = (1:length(xs))[.!ignores]
     fd = j′vp(fdm, f2, ȳ, sigargs...)
+    
     for (dx, ind) in zip(fd, arginds)
         args[ind] = dx
     end

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -28,7 +28,6 @@ Call `FiniteDifferences.j′vp`, with the option to ignore certain `xs`.
 - `∂xs::Tuple`: Derivatives estimated by finite differencing.
 """
 function _make_fdm_call(fdm, f, ȳ, xs, ignores)
-    ignores = collect(ignores)
     function f2(sigargs...)
         callargs = Any[]
         j = 1
@@ -46,12 +45,13 @@ function _make_fdm_call(fdm, f, ȳ, xs, ignores)
         return f(callargs...)
     end
 
+    ignores = collect(ignores)
     args = Any[nothing for _ in 1:length(xs)]
     all(ignores) && return (args...,)
     sigargs = xs[.!ignores]
     arginds = (1:length(xs))[.!ignores]
     fd = j′vp(fdm, f2, ȳ, sigargs...)
-    
+
     for (dx, ind) in zip(fd, arginds)
         args[ind] = dx
     end

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -71,7 +71,7 @@ fbtestkws(x, y; err = true) = err ? error() : x
     end
 
     @testset "symbol input: fsymtest" begin
-        fsymtest(x, s) = x
+        fsymtest(x, s::Symbol) = x
         ChainRulesCore.frule((_, Δx, _), ::typeof(fsymtest), x, s) = (x, Δx)
         function ChainRulesCore.rrule(::typeof(fsymtest), x, s)
             function fsymtest_pullback(Δx)

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -64,4 +64,22 @@
             rrule_test(first, randn(), (Tuple(randn(4)), CTuple{4}(randn(4)...)))
         end
     end
+
+    @testset "symbol input: fsymtest" begin
+        fsymtest(x, s) = x
+        ChainRulesCore.frule((_, Δx, _), ::typeof(fsymtest), x, s) = (x, Δx)
+        function ChainRulesCore.rrule(::typeof(fsymtest), x, s)
+            function fsymtest_pullback(Δx)
+                return NO_FIELDS, Δx, DoesNotExist()
+            end
+            return x, fsymtest_pullback
+        end
+
+        # @testset "frule_test" begin
+        #     frule_test(fsymtest, (randn(), randn()), (:x, nothing))
+        # end
+        @testset "rrule_test" begin
+            rrule_test(fsymtest, randn(), (randn(), randn()), (:x, nothing))
+        end
+    end
 end

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -75,9 +75,6 @@
             return x, fsymtest_pullback
         end
 
-        # @testset "frule_test" begin
-        #     frule_test(fsymtest, (randn(), randn()), (:x, nothing))
-        # end
         @testset "rrule_test" begin
             rrule_test(fsymtest, randn(), (randn(), randn()), (:x, nothing))
         end


### PR DESCRIPTION
This fixes #30 by removing the "terrifying" `eval` in `_make_fdm_call`.