### PR TITLE
Unify the two `rrule_test` functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -142,13 +142,9 @@ function rrule_test(f, ȳ, xx̄s::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm
     # use collect so can do vector equality
     @test isapprox(collect(y_ad), collect(y); rtol=rtol, atol=atol)
     @assert !(isa(ȳ, Thunk))
-    ∂s = if y_ad isa Tuple
-        # If the function returned multiple values,
-        # then it must have multiple seeds for propagating backwards
-        pullback(ȳ...)
-    else
-        pullback(ȳ)
-    end
+    # If the function returned multiple values,
+    # then it must have multiple seeds for propagating backwards
+    ∂s = (y_ad isa Tuple) ? pullback(ȳ...) : pullback(ȳ)
     ∂self = ∂s[1]
     x̄s_ad = ∂s[2:end]
     @test ∂self === NO_FIELDS  # No internal fields


### PR DESCRIPTION
This PR unifies the two `rrule_test` functions (single-arg and multi-arg). Because the single-arg version checked for approximate equality of outputs, while the multi-arg version iterated over the inputs, this PR partially resolves #29.