### PR TITLE
Remove special handling for pullbacks having multiple inputs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.2.7"
+version = "0.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ChainRulesCore = "0.7.1"
+ChainRulesCore = "0.8"
 Compat = "3"
 FiniteDifferences = "0.9"
 julia = "1"

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -147,9 +147,8 @@ function rrule_test(f, ȳ, xx̄s::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm
     # use collect so can do vector equality
     @test isapprox(collect(y_ad), collect(y); rtol=rtol, atol=atol)
     @assert !(isa(ȳ, Thunk))
-    # If the function returned multiple values,
-    # then it must have multiple seeds for propagating backwards
-    ∂s = (y_ad isa Tuple) ? pullback(ȳ...) : pullback(ȳ)
+    
+    ∂s = pullback(ȳ)
     ∂self = ∂s[1]
     x̄s_ad = ∂s[2:end]
     @test ∂self === NO_FIELDS  # No internal fields


### PR DESCRIPTION
https://github.com/JuliaDiff/ChainRulesCore.jl/issues/152

This is now slightly cleaner

We did not have tests that broken because of this, might be good to add some?
OTOH it is now a feature that doesn't exist, there is no longer a special case to test out.

This needs the ChainRulesCore PR to go in first
and then needs it s versions bumped