### PR TITLE
Bump compat for FiniteDifferences

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.2.7"
+version = "0.2.8"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -13,5 +13,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 ChainRulesCore = "0.7.1"
 Compat = "3"
-FiniteDifferences = "0.9"
+FiniteDifferences = "0.9, 0.10"
 julia = "1"


### PR DESCRIPTION
I can't think of any problems with doing this here. ChainRules has its own compat that will need to be bumped separately. Locally I've run ChainRules' test suite using FD v0.10.0, and all but one test set pass. But that can be handled in a ChainRules PR.

The rest of #31 will be handled in another PR.