### PR TITLE
Follow new complex rule conventions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.3.1"
+version = "0.4.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ChainRulesCore = "0.8"
+ChainRulesCore = "0.9"
 Compat = "3"
 FiniteDifferences = "0.9, 0.10"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -13,5 +13,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 ChainRulesCore = "0.9"
 Compat = "3"
-FiniteDifferences = "0.9, 0.10"
+FiniteDifferences = "0.10"
 julia = "1"

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -89,6 +89,8 @@ function test_scalar(f, x; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
 
         if rule == rrule
             ∂self, ∂x = ∂x
+            # un-conjugate to get same derivative as fdm/forward mode
+            ∂x = conj(∂x)
             @test ∂self === NO_FIELDS
         end
         @test isapprox(∂x, fdm(x -> f(x; fkwargs...), x); rtol=rtol, atol=atol, kwargs...)
@@ -147,7 +149,7 @@ function rrule_test(f, ȳ, xx̄s::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm
     # use collect so can do vector equality
     @test isapprox(collect(y_ad), collect(y); rtol=rtol, atol=atol)
     @assert !(isa(ȳ, Thunk))
-    
+
     ∂s = pullback(ȳ)
     ∂self = ∂s[1]
     x̄s_ad = ∂s[2:end]

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -71,6 +71,10 @@ at input point `x` to confirm that there are correct `frule` and `rrule`s provid
 
 `fkwargs` are passed to `f` as keyword arguments.
 All keyword arguments except for `fdm` and `fkwargs` are passed to `isapprox`.
+
+!!! note
+    this function has the same assumptions as the `@scalar_rule` macro. For example, it
+    assumes that a complex scalar function is holomorphic.
 """
 function test_scalar(f, x; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(), kwargs...)
     _ensure_not_running_on_functor(f, "test_scalar")

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -82,13 +82,13 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
     Δx = one(z)
     @testset "$f at $z, with tangent $Δx" begin
         # check ∂u_∂x and (if Ω is complex) ∂v_∂x via forward mode
-        frule_test(f, (z, Δx); rtol=rtol, atol=atol, fdm=fdm, fkwargs=fkwargs)
+        frule_test(f, (z, Δx); rtol=rtol, atol=atol, fdm=fdm, fkwargs=fkwargs, kwargs...)
     end
     if z isa Complex
         Δy = one(z) * im
         @testset "$f at $z, with tangent $Δy" begin
             # check ∂u_∂y and (if Ω is complex) ∂v_∂y via forward mode
-            frule_test(f, (z, Δy); rtol=rtol, atol=atol, fdm=fdm, fkwargs=fkwargs)
+            frule_test(f, (z, Δy); rtol=rtol, atol=atol, fdm=fdm, fkwargs=fkwargs, kwargs...)
         end
     end
 
@@ -96,13 +96,13 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
     Δu = one(Ω)
     @testset "$f at $z, with cotangent $Δu" begin
         # check ∂u_∂x and (if z is complex) ∂u_∂y via reverse mode
-        rrule_test(f, Δu, (z, Δx); rtol=rtol, atol=atol, fdm=fdm, fkwargs=fkwargs)
+        rrule_test(f, Δu, (z, Δx); rtol=rtol, atol=atol, fdm=fdm, fkwargs=fkwargs, kwargs...)
     end
     if Ω isa Complex
         Δv = one(Ω) * im
         @testset "$f at $z, with cotangent $Δv" begin
             # check ∂v_∂x and (if z is complex) ∂v_∂y via reverse mode
-            rrule_test(f, Δv, (z, Δx); rtol=rtol, atol=atol, fdm=fdm, fkwargs=fkwargs)
+            rrule_test(f, Δv, (z, Δx); rtol=rtol, atol=atol, fdm=fdm, fkwargs=fkwargs, kwargs...)
         end
     end
 end

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -83,6 +83,16 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
     @testset "$f at $z, with tangent $Δx" begin
         # check ∂u_∂x and (if Ω is complex) ∂v_∂x via forward mode
         frule_test(f, (z, Δx); rtol=rtol, atol=atol, fdm=fdm, fkwargs=fkwargs, kwargs...)
+        if z isa Complex
+            # check that same tangent is produced for tangent 1.0 and 1.0 + 0.0im
+            @test isapprox(
+                frule((Zero(), real(Δx)), f, z; fkwargs...)[2],
+                frule((Zero(), Δx), f, z; fkwargs...)[2],
+                rtol=rtol,
+                atol=atol,
+                kwargs...,
+            )
+        end
     end
     if z isa Complex
         Δy = one(z) * im
@@ -97,6 +107,17 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
     @testset "$f at $z, with cotangent $Δu" begin
         # check ∂u_∂x and (if z is complex) ∂u_∂y via reverse mode
         rrule_test(f, Δu, (z, Δx); rtol=rtol, atol=atol, fdm=fdm, fkwargs=fkwargs, kwargs...)
+        if Ω isa Complex
+            # check that same cotangent is produced for cotangent 1.0 and 1.0 + 0.0im
+            back = rrule(f, z)[2]
+            @test isapprox(
+                extern(back(real(Δu))[2]),
+                extern(back(Δu)[2]),
+                rtol=rtol,
+                atol=atol,
+                kwargs...,
+            )
+        end
     end
     if Ω isa Complex
         Δv = one(Ω) * im

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -38,6 +38,9 @@ sinconj(x) = sin(x)
         # define rrule using ChainRulesCore's v0.9.0 convention, conjugating the derivative
         # in the rrule
         function ChainRulesCore.rrule(::typeof(sinconj), x)
+            # usually we would not thunk for a single output, because it will of course be
+            # used, but we do here to ensure that test_scalar works even if a scalar rrule
+            # thunks
             sinconj_pullback(ΔΩ) = (NO_FIELDS, @thunk(conj(cos(x)) * ΔΩ))
             return sin(x), sinconj_pullback
         end

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -9,7 +9,7 @@ sinconj(x) = sin(x)
     @testset "test_scalar" begin
         double(x) = 2x
         @scalar_rule(double(x), 2)
-        test_scalar(double, 2)
+        test_scalar(double, 2.0)
     end
 
     @testset "unary: identity(x)" begin
@@ -41,6 +41,7 @@ sinconj(x) = sin(x)
             sinconj_pullback(ΔΩ) = (NO_FIELDS, @thunk(conj(cos(x)) * ΔΩ))
             return sin(x), sinconj_pullback
         end
+
         rrule_test(sinconj, randn(ComplexF64), (randn(ComplexF64), randn(ComplexF64)))
         test_scalar(sinconj, randn(ComplexF64))
     end


### PR DESCRIPTION
Following https://github.com/JuliaDiff/ChainRules.jl/issues/210, this PR:
- Bumps compat for ChainRulesCore to v0.9
- ~Updates `ChainRulesTestUtils.test_scalar` to conjugate the derivative when testing `rrule`.~ Reimplements `test_scalar` to test entire Jacobian in forward and reverse mode.
- Bumps compat for FiniteDifferences to v0.10 (required for tests of complex functions to consistently work)
