### PR TITLE
Check frule primal with isapprox

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -143,7 +143,8 @@ function frule_test(f, xẋs::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm=_fdm
     _ensure_not_running_on_functor(f, "frule_test")
     xs, ẋs = first.(xẋs), last.(xẋs)
     Ω, dΩ_ad = frule((NO_FIELDS, ẋs...), f, xs...; fkwargs...)
-    @test f(xs...; fkwargs...) == Ω
+    # use collect so can do vector equality
+    @test isapprox(collect(Ω), collect(f(xs...; fkwargs...)); rtol=rtol, atol=atol)
 
     # Correctness testing via finite differencing.
     dΩ_fd = jvp(fdm, xs->f(xs...; fkwargs...), (xs, ẋs))


### PR DESCRIPTION
`frule_test` currently requires the primal output of `frule` of `f` to be exactly equal to the output of `f`. We previously relaxed this requirement for `rrule_test` (#33), and this PR just uses the same check for `frule_test`.

The ChainRules test suite still passes for me with this change.