### PR TITLE
Add ChainRules integration tests

### DIFF
--- a/.github/workflows/IntegrationTestChainRules.yml
+++ b/.github/workflows/IntegrationTestChainRules.yml
@@ -1,0 +1,30 @@
+name: IntegrationTestChainRules 
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: Julia v${{ matrix.julia-version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1]
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone ChainRules
+        uses: actions/checkout@v2
+        with:
+          repository: JuliaDiff/ChainRules.jl
+          path: "ChainRules.jl"
+      - name: Run the tests
+        run: julia --project="ChainRules.jl" -e "using Pkg; Pkg.develop(PackageSpec(path=\"./\")); Pkg.update(); Pkg.test()"
+        shell: bash


### PR DESCRIPTION
Usually when I make a change to the testers, I end up locally running the ChainRules test suite to make sure I didn't overlook some edge case. This PR adds the same integration tests that https://github.com/JuliaDiff/ChainRulesCore.jl/pull/193 added to ChainRulesCore.