### PR TITLE
Check that if only one adjoint exists, it is not thunked

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.4.3"
+version = "0.5.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -206,7 +206,7 @@ function rrule_test(f, ȳ, xx̄s::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm
 
     if count(!, x̄s_is_dne) == 1
         # for functions with pullbacks that only produce a single non-DNE adjoint, that
-        # single adjoint should not be thunked.
+        # single adjoint should not be `Thunk`ed. InplaceableThunk is fine.
         i = findfirst(!, x̄s_is_dne)
         @test !(isa(x̄s_ad[i], Thunk))
     end

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -40,10 +40,7 @@ primalapprox(x) = x
         # define rrule using ChainRulesCore's v0.9.0 convention, conjugating the derivative
         # in the rrule
         function ChainRulesCore.rrule(::typeof(sinconj), x)
-            # usually we would not thunk for a single output, because it will of course be
-            # used, but we do here to ensure that test_scalar works even if a scalar rrule
-            # thunks
-            sinconj_pullback(ΔΩ) = (NO_FIELDS, @thunk(conj(cos(x)) * ΔΩ))
+            sinconj_pullback(ΔΩ) = (NO_FIELDS, conj(cos(x)) * ΔΩ)
             return sin(x), sinconj_pullback
         end
 


### PR DESCRIPTION
Currently, the (unenforced) standard is that single-argument functions do not thunk in the pullback. On https://github.com/JuliaDiff/ChainRules.jl/pull/182, @willtebbutt and I were discussing whether we should extend that so that if there is only a single meaningful argument, then that argument's adjoint should not be thunked. This PR takes that opinion and adds a conservative test to `rrule_test`: namely, for functions whose pullbacks only produce one adjoint that is not `DoesNotExist`, that single adjoint is not thunked.

This is more to generate discussion. As you can see in the [integration test](https://github.com/JuliaDiff/ChainRulesTestUtils.jl/runs/863569612?check_suite_focus=true#step:6:1693), several pullbacks in ChainRules break this proposed rule:
- `sum`
- `mean`
- `tr`
- `diag`
- `Symmetric`
- `Hermitian`
- `Adjoint`
- `adjoint`
- `Transpose`
- `transpose`
- `UpperTriangular`
- `LowerTriangular`
- `triu`
- `tril`
- `asum`