### PR TITLE
Make frule_test work for functions with non-differentiable args

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.5.0"
+version = "0.5.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -42,8 +42,6 @@ function _wrap_function(f, xs, ignores)
     return fnew
 end
 
-@deprecate _make_fdm_call(fdm, f, ȳ, xs, ignores) _make_j′vp_call(fdm, f, ȳ, xs, ignores)
-
 """
     _make_j′vp_call(fdm, f, ȳ, xs, ignores) -> Tuple
 

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -42,8 +42,10 @@ function _wrap_function(f, xs, ignores)
     return fnew
 end
 
+@deprecate _make_fdm_call(fdm, f, ȳ, xs, ignores) _make_j′vp_call(fdm, f, ȳ, xs, ignores)
+
 """
-    _make_fdm_call(fdm, f, ȳ, xs, ignores) -> Tuple
+    _make_j′vp_call(fdm, f, ȳ, xs, ignores) -> Tuple
 
 Call `FiniteDifferences.j′vp`, with the option to ignore certain `xs`.
 
@@ -58,7 +60,7 @@ Call `FiniteDifferences.j′vp`, with the option to ignore certain `xs`.
 # Returns
 - `∂xs::Tuple`: Derivatives estimated by finite differencing.
 """
-function _make_fdm_call(fdm, f, ȳ, xs, ignores)
+function _make_j′vp_call(fdm, f, ȳ, xs, ignores)
     f2 = _wrap_function(f, xs, ignores)
 
     ignores = collect(ignores)
@@ -210,7 +212,7 @@ function rrule_test(f, ȳ, xx̄s::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm
 
     x̄s_is_dne = x̄s .== nothing
     # Correctness testing via finite differencing.
-    x̄s_fd = _make_fdm_call(fdm, (xs...) -> f(xs...; fkwargs...), ȳ, xs, x̄s_is_dne)
+    x̄s_fd = _make_j′vp_call(fdm, (xs...) -> f(xs...; fkwargs...), ȳ, xs, x̄s_is_dne)
     for (x̄_ad, x̄_fd) in zip(x̄s_ad, x̄s_fd)
         if x̄_fd === nothing
             # The way we've structured the above, this tests the propagator is returning a DoesNotExist

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -143,7 +143,7 @@ end
         end
     end
 
-    @testset "symbol input: fsymtest" begin
+    @testset "ignoring arguments" begin
         fsymtest(x, s::Symbol) = x
         ChainRulesCore.frule((_, Δx, _), ::typeof(fsymtest), x, s) = (x, Δx)
         function ChainRulesCore.rrule(::typeof(fsymtest), x, s)

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -120,6 +120,10 @@ primalapprox(x) = x
             return x, fsymtest_pullback
         end
 
+        @testset "frule_test" begin
+            frule_test(fsymtest, (randn(), randn()), (:x, nothing))
+        end
+
         @testset "rrule_test" begin
             rrule_test(fsymtest, randn(), (randn(), randn()), (:x, nothing))
         end


### PR DESCRIPTION
Adds the same ability for `frule_test` that we currently have for `rrule_test`. Namely, specify a differential for an argument as `nothing` for `frule_test` to make that argument invisible to finite differences. Enables testing of rules for functions like `Symmetric(randn(3, 3), :U)`.