### PR TITLE
Test the unhappy path

### DIFF
--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -9,24 +9,24 @@ using Test: DefaultTestSet
     nonpassing_results(f)
 
 `f` should be a function that takes no argument, and calls some code that used `@test`.
-Invoking it via `metatest_get_failures(f)` will prevent those `@test` being added to the
+Invoking it via `nonpassing_results(f)` will prevent those `@test` being added to the
 current testset, and will return a collection of all nonpassing test results.
 """
 function nonpassing_results(f)
     mute() do
-        failures = []
+        nonpasses = []
         # Specify testset type incase parent testset is some other typer
         @testset DefaultTestSet "nonpassing internal" begin
             f()
             ts = Test.get_testset()  # this is the current testset "nonpassing internal"
-            failures = _extract_nonpasses(ts)
+            nonpasses = _extract_nonpasses(ts)
             # Prevent the failure being recorded in parent testset.
             empty!(ts.results)
             ts.anynonpass = false
         end
         # Note: we allow the "nonpassing internal" testset to still be pushed as an empty
         # passing testset in its parent testset. We could remove that if we wanted
-        return failures
+        return nonpasses
     end
 end
 

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -14,7 +14,7 @@ function metatest_get_failures(f)
         failures = []
         @testset "dummy" begin
             f()
-            ts = Test.get_testset()
+            ts = Test.get_testset()  # this is the current testset "dummy"
             failures = _extract_failures(ts)
             # Prevent the failure being recorded in parent testset.
             empty!(ts.results)

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -10,18 +10,22 @@ Invoking it via `metatest_get_failures(f)` will prevent those `@test` being adde
 current testset, and will return a collection of all nonpassing test results.
 """
 function metatest_get_failures(f)
-    redirect_stdout(devnull) do
-        failures = []
-        @testset "dummy" begin
-            f()
-            ts = Test.get_testset()  # this is the current testset "dummy"
-            failures = _extract_failures(ts)
-            # Prevent the failure being recorded in parent testset.
-            empty!(ts.results)
-            ts.anynonpass = false
-        end
-        return failures
-   end
+    # TODO: once we are on Julia 1.6 this can be change to just use
+    # `redirect_stdout(devnull)` See: https://github.com/JuliaLang/julia/pull/36146
+    mktemp() do path, tempio
+        redirect_stdout(tempio) do 
+            failures = []
+            @testset "dummy" begin
+                f()
+                ts = Test.get_testset()  # this is the current testset "dummy"
+                failures = _extract_failures(ts)
+                # Prevent the failure being recorded in parent testset.
+                empty!(ts.results)
+                ts.anynonpass = false
+            end
+            return failures
+       end
+    end
 end
 
 "extracts as flat collection of failures from a (potential nested) testset"

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -10,7 +10,7 @@ Invoking it via `metatest_get_failures(f)` will prevent those `@test` being adde
 current testset, and will return a collection of all nonpassing test results.
 """
 function metatest_get_failures(f)
-    redirect_stdout(stdout) do
+    redirect_stdout(devnull) do
         failures = []
         @testset "dummy" begin
             f()

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -1,0 +1,71 @@
+# This is tools for testing ChainRulesTestUtils itself
+# if they were less nasty in implementation we might consider moving them to a package
+# MetaTesting.jl
+
+"""
+    metatest_get_failures(f)
+
+`f` should be a function that takes no argument, and calls some code that used `@test`.
+Invoking it via `metatest_get_failures(f)` will prevent those `@test` being added to the
+current testset, and will return a collection of all nonpassing test results.
+"""
+function metatest_get_failures(f)
+    redirect_stdout(stdout) do
+        failures = []
+        @testset "dummy" begin
+            f()
+            ts = Test.get_testset()
+            failures = _extract_failures(ts)
+            # Prevent the failure being recorded in parent testset.
+            empty!(ts.results)
+            ts.anynonpass = false
+        end
+        return failures
+   end
+end
+
+"extracts as flat collection of failures from a (potential nested) testset"
+_extract_failures(x::Test.Result) = [x,]
+_extract_failures(x::Test.Pass) = Test.Result[]
+_extract_failures(ts::Test.DefaultTestSet) = _extract_failures(ts.results)
+function _extract_failures(xs::Vector)
+    if isempty(xs)
+        return Test.Result[]
+    else
+        return mapreduce(_extract_failures, vcat, xs)
+    end
+end
+
+#Meta Meta tests
+@testset "meta_testing_tools.jl" begin
+    @testset "metatest_get_failures" begin
+        @testset "No Tests" begin
+            fails = metatest_get_failures(()->nothing)
+            @test length(fails) === 0
+        end
+
+        @testset "No Failures" begin
+            fails = metatest_get_failures(()->@test true)
+            @test length(fails) === 0
+        end
+
+
+        @testset "Single Test" begin
+            fails = metatest_get_failures(()->@test false)
+            @test length(fails) === 1
+            @test fails[1].orig_expr == false
+        end
+
+        @testset "Single Testset" begin
+            fails = metatest_get_failures() do
+                @testset "inner" begin
+                    @test false == true
+                    @test true == false
+                end
+            end
+            @test length(fails) === 2
+            @test fails[1].orig_expr == :(false==true)
+            @test fails[2].orig_expr == :(true==false)
+        end
+    end
+end

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -2,66 +2,105 @@
 # if they were less nasty in implementation we might consider moving them to a package
 # MetaTesting.jl
 
+# need to bring this into scope explictly so can use in @testset nonpassing_results
+using Test: DefaultTestSet
+
 """
-    metatest_get_failures(f)
+    nonpassing_results(f)
 
 `f` should be a function that takes no argument, and calls some code that used `@test`.
 Invoking it via `metatest_get_failures(f)` will prevent those `@test` being added to the
 current testset, and will return a collection of all nonpassing test results.
 """
-function metatest_get_failures(f)
+function nonpassing_results(f)
+    mute() do
+        failures = []
+        # Specify testset type incase parent testset is some other typer
+        @testset DefaultTestSet "nonpassing internal" begin
+            f()
+            ts = Test.get_testset()  # this is the current testset "nonpassing internal"
+            failures = _extract_nonpasses(ts)
+            # Prevent the failure being recorded in parent testset.
+            empty!(ts.results)
+            ts.anynonpass = false
+        end
+        # Note: we allow the "nonpassing internal" testset to still be pushed as an empty
+        # passing testset in its parent testset. We could remove that if we wanted
+        return failures
+    end
+end
+
+"""
+    mute(f)
+
+Calls `f()` silencing stdout.
+"""
+function mute(f)
     # TODO: once we are on Julia 1.6 this can be change to just use
     # `redirect_stdout(devnull)` See: https://github.com/JuliaLang/julia/pull/36146
     mktemp() do path, tempio
-        redirect_stdout(tempio) do 
-            failures = []
-            @testset "dummy" begin
-                f()
-                ts = Test.get_testset()  # this is the current testset "dummy"
-                failures = _extract_failures(ts)
-                # Prevent the failure being recorded in parent testset.
-                empty!(ts.results)
-                ts.anynonpass = false
-            end
-            return failures
-       end
+        redirect_stdout(tempio) do
+            f()
+        end
     end
 end
 
 "extracts as flat collection of failures from a (potential nested) testset"
-_extract_failures(x::Test.Result) = [x,]
-_extract_failures(x::Test.Pass) = Test.Result[]
-_extract_failures(ts::Test.DefaultTestSet) = _extract_failures(ts.results)
-function _extract_failures(xs::Vector)
+_extract_nonpasses(x::Test.Result) = [x,]
+_extract_nonpasses(x::Test.Pass) = Test.Result[]
+_extract_nonpasses(ts::Test.DefaultTestSet) = _extract_nonpasses(ts.results)
+function _extract_nonpasses(xs::Vector)
     if isempty(xs)
         return Test.Result[]
     else
-        return mapreduce(_extract_failures, vcat, xs)
+        return mapreduce(_extract_nonpasses, vcat, xs)
     end
+end
+
+"""
+    fails(f)
+
+`f` should be a function that takes no argument, and calls some code that used `@test`.
+`fails(f)` returns true if at least 1 `@test` fails.
+If a test errors then it will display that error and throw an error of its own.
+"""
+function fails(f)
+    results = nonpassing_results(f)
+    did_fail = false
+    for result in results
+        did_fail |= result isa Test.Fail
+        if result isa Test.Error
+            # Log a error message, with original backtrace
+            show(result)
+            # Sadly we can't throw the original exception as it is only stored as a String
+            error("Error occurred during `fails`")
+        end
+    end
+    return did_fail
 end
 
 #Meta Meta tests
 @testset "meta_testing_tools.jl" begin
-    @testset "metatest_get_failures" begin
+    @testset "Checking for non-passes" begin
         @testset "No Tests" begin
-            fails = metatest_get_failures(()->nothing)
+            fails = nonpassing_results(()->nothing)
             @test length(fails) === 0
         end
 
         @testset "No Failures" begin
-            fails = metatest_get_failures(()->@test true)
+            fails = nonpassing_results(()->@test true)
             @test length(fails) === 0
         end
 
 
         @testset "Single Test" begin
-            fails = metatest_get_failures(()->@test false)
+            fails = nonpassing_results(()->@test false)
             @test length(fails) === 1
             @test fails[1].orig_expr == false
         end
 
         @testset "Single Testset" begin
-            fails = metatest_get_failures() do
+            fails = nonpassing_results() do
                 @testset "inner" begin
                     @test false == true
                     @test true == false
@@ -70,6 +109,24 @@ end
             @test length(fails) === 2
             @test fails[1].orig_expr == :(false==true)
             @test fails[2].orig_expr == :(true==false)
+        end
+    end
+
+    @testset "fails" begin
+        @test !fails(()->@test true)
+        @test fails(()->@test false)
+        @test !fails(()->@test_broken false)
+
+        @test fails() do
+            @testset "eg" begin
+                @test true
+                @test false
+                @test true
+            end
+        end
+
+        @test_throws Exception mute() do  # mute it so we don't see the reprinted error.
+            fails(()->@test error("Bad"))
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Random
 using Test
 
 @testset "ChainRulesTestUtils.jl" begin
+    include("meta_testing_tools.jl")
     include("generate_tangent.jl")
     include("to_vec.jl")
     include("isapprox.jl")

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -276,7 +276,7 @@ end
         @testset "primal wrong" begin
             my_identity1(x) = x
             function ChainRulesCore.frule((_, ẏ), ::typeof(my_identity1), x)
-                return 2.5*x, ẏ
+                return 2.5 * x, ẏ
             end
             function ChainRulesCore.rrule(::typeof(my_identity1), x)
                 function identity_pullback(ȳ)

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -42,16 +42,15 @@ end
 
 @testset "testers.jl" begin
     @testset "test_scalar" begin
-        @testset "happy path" begin
+        @testset "Ensure correct rules succeed" begin
             double(x) = 2x
             @scalar_rule(double(x), 2)
             test_scalar(double, 2.1)
         end
-        @testset "unhappy path" begin
+        @testset "Ensure incorrect rules caught" begin
             alt_double(x) = 2x
             @scalar_rule(alt_double(x), 3)  # this is wrong, on purpose
-            failures = metatest_get_failures(()->test_scalar(alt_double, 2.1))
-            @test !isempty(failures)
+            @test fails(()->test_scalar(alt_double, 2.1))
         end
     end
 
@@ -285,10 +284,8 @@ end
                 return 2.5 * x, identity_pullback
             end
 
-            @test !isempty(metatest_get_failures(()->frule_test(my_identity1, (2.2, 3.3))))
-            @test !isempty(metatest_get_failures(
-                ()->rrule_test(my_identity1, 4.1, (2.2, 3.3)))
-            )
+            @test fails(()->frule_test(my_identity1, (2.2, 3.3))))
+            @test fails(()->rrule_test(my_identity1, 4.1, (2.2, 3.3))))
         end
 
         @testset "deriviative wrong" begin
@@ -303,10 +300,8 @@ end
                 return x, identity_pullback
             end
 
-            @test !isempty(metatest_get_failures(()->frule_test(my_identity2, (2.2, 3.3))))
-            @test !isempty(metatest_get_failures(
-                ()->rrule_test(my_identity2, 4.1, (2.2, 3.3)))
-            )
+            @test fails(()->frule_test(my_identity2, (2.2, 3.3)))
+            @test fails(()->rrule_test(my_identity2, 4.1, (2.2, 3.3)))
         end
     end
 end

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -42,9 +42,17 @@ end
 
 @testset "testers.jl" begin
     @testset "test_scalar" begin
-        double(x) = 2x
-        @scalar_rule(double(x), 2)
-        test_scalar(double, 2.0)
+        @testset "happy path" begin
+            double(x) = 2x
+            @scalar_rule(double(x), 2)
+            test_scalar(double, 2.1)
+        end
+        @testset "unhappy path" begin
+            alt_double(x) = 2x
+            @scalar_rule(alt_double(x), 3)  # this is wrong, on purpose
+            failures = metatest_get_failures(()->test_scalar(alt_double, 2.1))
+            @test !isempty(failures)
+        end
     end
 
     @testset "unary: identity(x)" begin
@@ -262,5 +270,43 @@ end
 
         frule_test(iterfun, (x, ẋ))
         rrule_test(iterfun, randn(), (x, x̄))
+    end
+
+    @testset "unhappy path" begin
+        @testset "primal wrong" begin
+            my_identity1(x) = x
+            function ChainRulesCore.frule((_, ẏ), ::typeof(my_identity1), x)
+                return 2.5*x, ẏ
+            end
+            function ChainRulesCore.rrule(::typeof(my_identity1), x)
+                function identity_pullback(ȳ)
+                    return (NO_FIELDS, ȳ)
+                end
+                return 2.5 * x, identity_pullback
+            end
+
+            @test !isempty(metatest_get_failures(()->frule_test(my_identity1, (2.2, 3.3))))
+            @test !isempty(metatest_get_failures(
+                ()->rrule_test(my_identity1, 4.1, (2.2, 3.3)))
+            )
+        end
+
+        @testset "deriviative wrong" begin
+            my_identity2(x) = x
+            function ChainRulesCore.frule((_, ẏ), ::typeof(my_identity2), x)
+                return x, 2.7 * ẏ
+            end
+            function ChainRulesCore.rrule(::typeof(my_identity2), x)
+                function identity_pullback(ȳ)
+                    return (NO_FIELDS, 31.8 * ȳ)
+                end
+                return x, identity_pullback
+            end
+
+            @test !isempty(metatest_get_failures(()->frule_test(my_identity2, (2.2, 3.3))))
+            @test !isempty(metatest_get_failures(
+                ()->rrule_test(my_identity2, 4.1, (2.2, 3.3)))
+            )
+        end
     end
 end

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -284,8 +284,8 @@ end
                 return 2.5 * x, identity_pullback
             end
 
-            @test fails(()->frule_test(my_identity1, (2.2, 3.3))))
-            @test fails(()->rrule_test(my_identity1, 4.1, (2.2, 3.3))))
+            @test fails(()->frule_test(my_identity1, (2.2, 3.3)))
+            @test fails(()->rrule_test(my_identity1, 4.1, (2.2, 3.3)))
         end
 
         @testset "deriviative wrong" begin


### PR DESCRIPTION
This PR is about testing that we can actually detect when things are wrong.

The code for `metatest_get_failures` is a pretty nasty hack an on the internals.
I think its clear enough what it is doing.

Two possible alternative implementations:

### Alt 1: use a seperate process.
Julia itself does this to test `@test`.
Writing a test to a file and then kicking it off with ``run(`julia -e file.jl`)``
But three problems are

1. Slow starting an external process is slow
2. Very course grained: all that is easy to test is that it caused julia to to exit with a nonzero status
3. Pretty ugly code, need to redirect stdout still and need to write a file

### Alt 2: custom Testset type
We could declare a custom testset type which overloads `record` and `finish` so that they don't propate errors upwards.
This might be fiddly, but I have done something like it before in https://github.com/JuliaTesting/ReferenceTests.jl.
so could base it off that.
It should be simplier than that.
It could be pretty clean maybe. Not 100% sure.