### PR TITLE
Support non-standard scalars in test_scalar

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,4 +14,11 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ChainRulesCore = "0.9.1"
 Compat = "3"
 FiniteDifferences = "0.10"
+Quaternions = "0.4"
 julia = "1"
+
+[extras]
+Quaternions = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
+
+[targets]
+test = ["Quaternions"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -112,6 +112,9 @@ at input point `z` to confirm that there are correct `frule` and `rrule`s provid
 
 `fkwargs` are passed to `f` as keyword arguments.
 All keyword arguments except for `fdm` and `fkwargs` are passed to `isapprox`.
+
+To use this tester for a scalar type `MyNumber <: AbstractNumber`,
+`FiniteDifferences.to_vec(::MyNumber)` must be implemented.
 """
 function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(), kwargs...)
     _ensure_not_running_on_functor(f, "test_scalar")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using ChainRulesCore
 using ChainRulesTestUtils
+using FiniteDifferences
 using LinearAlgebra
 using Quaternions
 using Random

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using ChainRulesCore
 using ChainRulesTestUtils
 using LinearAlgebra
+using Quaternions
 using Random
 using Test
 


### PR DESCRIPTION
`test_scalar` currently is very `Real` and `Complex` focused. This PR generalizes `test_scalar` to work the same for any scalar for which `FiniteDifferences.to_vec` (and a handful of base functions) are implemented.

We test it with `Quaternions.Quaternion`. We'd ideally test against a more minimal number, but it turns out one needs to implement quite a few base methods to get a new number to work correctly.