### PR TITLE
stringify orig_expr in meta-metatests

### DIFF
--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -96,7 +96,10 @@ end
         @testset "Single Test" begin
             fails = nonpassing_results(()->@test false)
             @test length(fails) === 1
-            @test fails[1].orig_expr == false
+            # Julia 1.6 return a `String`, not an `Expr`.
+            # Always calling  `string` on it gives gives consistency regardless of version.
+            # https://github.com/JuliaLang/julia/pull/37809
+            @test string(fails[1].orig_expr) == string(false)
         end
 
         @testset "Single Testset" begin
@@ -107,13 +110,12 @@ end
                 end
             end
             @test length(fails) === 2
-            
 
-            # Newer versions of Julia return a `String`, not an `Expr`. 
+            # Julia 1.6 return a `String`, not an `Expr`.
             # Always calling  `string` on it gives gives consistency regardless of version.
             # https://github.com/JuliaLang/julia/pull/37809
-            @test string(fails[1].orig_expr) == "false == true"
-            @test string(fails[2].orig_expr) == "true == false"
+            @test string(fails[1].orig_expr) == string(:(false == true))
+            @test string(fails[2].orig_expr) == string(:(true == false))
         end
     end
 

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -107,8 +107,13 @@ end
                 end
             end
             @test length(fails) === 2
-            @test fails[1].orig_expr == :(false==true)
-            @test fails[2].orig_expr == :(true==false)
+            
+
+            # Newer versions of Julia return a `String`, not an `Expr`. 
+            # Always calling  `string` on it gives gives consistency regardless of version.
+            # https://github.com/JuliaLang/julia/pull/37809
+            @test string(fails[1].orig_expr) == "false == true"
+            @test string(fails[2].orig_expr) == "true == false"
         end
     end
 


### PR DESCRIPTION
Julia broke this on current master
https://github.com/JuliaLang/julia/pull/37809#issuecomment-712162789

I am not particularly in a hurry to see this merged.
I don't love this change, since it is now sensitive to the spacing that julia happens to use for `==`