### PR TITLE
add support of 0-dim array for `rand_tangent`

### DIFF
--- a/src/generate_tangent.jl
+++ b/src/generate_tangent.jl
@@ -13,11 +13,7 @@ rand_tangent(rng::AbstractRNG, x::Integer) = DoesNotExist()
 
 rand_tangent(rng::AbstractRNG, x::T) where {T<:Number} = randn(rng, T)
 
-function rand_tangent(rng::AbstractRNG, x::StridedArray{T,0}) where {T}
-    return fill(rand_tangent(rng, x[]))
-end
-
-rand_tangent(rng::AbstractRNG, x::StridedArray) = rand_tangent.(Ref(rng), x)
+rand_tangent(rng::AbstractRNG, x::StridedArray) = map(x_ -> rand_tangent(rng, x_), x)
 
 function rand_tangent(rng::AbstractRNG, x::T) where {T<:Tuple}
     return Composite{T}(rand_tangent.(Ref(rng), x)...)

--- a/src/generate_tangent.jl
+++ b/src/generate_tangent.jl
@@ -13,6 +13,10 @@ rand_tangent(rng::AbstractRNG, x::Integer) = DoesNotExist()
 
 rand_tangent(rng::AbstractRNG, x::T) where {T<:Number} = randn(rng, T)
 
+function rand_tangent(rng::AbstractRNG, x::StridedArray{T,0}) where {T}
+    return fill(rand_tangent(rng, x[]))
+end
+
 rand_tangent(rng::AbstractRNG, x::StridedArray) = rand_tangent.(Ref(rng), x)
 
 function rand_tangent(rng::AbstractRNG, x::T) where {T<:Tuple}

--- a/test/generate_tangent.jl
+++ b/test/generate_tangent.jl
@@ -18,7 +18,7 @@ end
         (4, DoesNotExist),
         (5.0, Float64),
         (5.0 + 0.4im, Complex{Float64}),
-        (fill(6.0), Array{Float64,0}),
+        (fill(6.0), Array{Float64, 0}),
         (randn(Float32, 3), Vector{Float32}),
         (randn(Complex{Float64}, 2), Vector{Complex{Float64}}),
         (randn(5, 4), Matrix{Float64}),

--- a/test/generate_tangent.jl
+++ b/test/generate_tangent.jl
@@ -18,6 +18,7 @@ end
         (4, DoesNotExist),
         (5.0, Float64),
         (5.0 + 0.4im, Complex{Float64}),
+        (fill(6.0), Array{Float64,0}),
         (randn(Float32, 3), Vector{Float32}),
         (randn(Complex{Float64}, 2), Vector{Complex{Float64}}),
         (randn(5, 4), Matrix{Float64}),


### PR DESCRIPTION
This patch fixes
```julia
a = fill(1.0) # typeof(a) == Array{Float64,0}
b = rand_tangent(a) # typeof(b) == Float64
typeof(a) == typeof(b) # => false
```