### PR TITLE
Support testing mutating functions in frule_test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -183,8 +183,8 @@ All keyword arguments except for `fdm` and `fkwargs` are passed to `isapprox`.
 function frule_test(f, xẋs::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(), kwargs...)
     _ensure_not_running_on_functor(f, "frule_test")
     xs, ẋs = first.(xẋs), last.(xẋs)
-    Ω_ad, dΩ_ad = frule((NO_FIELDS, ẋs...), f, xs...; fkwargs...)
-    Ω = f(xs...; fkwargs...)
+    Ω_ad, dΩ_ad = frule((NO_FIELDS, deepcopy(ẋs)...), f, deepcopy(xs)...; deepcopy(fkwargs)...)
+    Ω = f(deepcopy(xs)...; deepcopy(fkwargs)...)
     # if equality check fails, check approximate equality
     # use collect so can do vector equality
     # TODO: add isapprox replacement that works for more types
@@ -192,7 +192,7 @@ function frule_test(f, xẋs::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm=_fdm
 
     ẋs_is_ignored = ẋs .== nothing
     # Correctness testing via finite differencing.
-    dΩ_fd = _make_jvp_call(fdm, (xs...) -> f(xs...; fkwargs...), xs, ẋs, ẋs_is_ignored)
+    dΩ_fd = _make_jvp_call(fdm, (xs...) -> f(deepcopy(xs)...; deepcopy(fkwargs)...), xs, ẋs, ẋs_is_ignored)
     @test isapprox(
         collect(extern.(dΩ_ad)),  # Use collect so can use vector equality
         collect(dΩ_fd);

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -192,7 +192,7 @@ function frule_test(f, xẋs::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm=_fdm
 
     ẋs_is_ignored = ẋs .== nothing
     # Correctness testing via finite differencing.
-    dΩ_fd = _make_jvp_call(fdm, (xs...) -> f(deepcopy(xs)...; deepcopy(fkwargs)...), xs, ẋs, ẋs_is_ignored)
+    dΩ_fd = _make_jvp_call(fdm, (xs...) -> deepcopy(f)(deepcopy(xs)...; deepcopy(fkwargs)...), xs, ẋs, ẋs_is_ignored)
     @test isapprox(
         collect(extern.(dΩ_ad)),  # Use collect so can use vector equality
         collect(dΩ_fd);

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -192,7 +192,7 @@ function frule_test(f, xẋs::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm=_fdm
 
     ẋs_is_ignored = ẋs .== nothing
     # Correctness testing via finite differencing.
-    dΩ_fd = _make_jvp_call(fdm, (xs...) -> deepcopy(f)(deepcopy(xs)...; deepcopy(fkwargs)...), xs, ẋs, ẋs_is_ignored)
+    dΩ_fd = _make_jvp_call(fdm, (xs...) -> f(deepcopy(xs)...; deepcopy(fkwargs)...), xs, ẋs, ẋs_is_ignored)
     @test isapprox(
         collect(extern.(dΩ_ad)),  # Use collect so can use vector equality
         collect(dΩ_fd);

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -183,8 +183,8 @@ All keyword arguments except for `fdm` and `fkwargs` are passed to `isapprox`.
 function frule_test(f, xẋs::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(), kwargs...)
     _ensure_not_running_on_functor(f, "frule_test")
     xs, ẋs = first.(xẋs), last.(xẋs)
-    Ω_ad, dΩ_ad = frule((NO_FIELDS, deepcopy(ẋs)...), deepcopy(f), deepcopy(xs)...; deepcopy(fkwargs)...)
-    Ω = deepcopy(f)(deepcopy(xs)...; deepcopy(fkwargs)...)
+    Ω_ad, dΩ_ad = frule((NO_FIELDS, deepcopy(ẋs)...), f, deepcopy(xs)...; deepcopy(fkwargs)...)
+    Ω = f(deepcopy(xs)...; deepcopy(fkwargs)...)
     # if equality check fails, check approximate equality
     # use collect so can do vector equality
     # TODO: add isapprox replacement that works for more types

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -183,8 +183,8 @@ All keyword arguments except for `fdm` and `fkwargs` are passed to `isapprox`.
 function frule_test(f, xẋs::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(), kwargs...)
     _ensure_not_running_on_functor(f, "frule_test")
     xs, ẋs = first.(xẋs), last.(xẋs)
-    Ω_ad, dΩ_ad = frule((NO_FIELDS, deepcopy(ẋs)...), f, deepcopy(xs)...; deepcopy(fkwargs)...)
-    Ω = f(deepcopy(xs)...; deepcopy(fkwargs)...)
+    Ω_ad, dΩ_ad = frule((NO_FIELDS, deepcopy(ẋs)...), deepcopy(f), deepcopy(xs)...; deepcopy(fkwargs)...)
+    Ω = deepcopy(f)(deepcopy(xs)...; deepcopy(fkwargs)...)
     # if equality check fails, check approximate equality
     # use collect so can do vector equality
     # TODO: add isapprox replacement that works for more types


### PR DESCRIPTION
This PR makes `frule_test` `deepcopy` all inputs, function kwargs, and tangents before function calls, which enables it to be used to test functions that mutate their inputs. Relates #35.