### PR TITLE
support isapprox still

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -27,7 +27,8 @@ end
 
 """
     _can_pass_early(actual, expected; kwargs...)
-Used to check if we actual is basically equal to expected, so we don't need to check deeper.
+Used to check if `actual` is basically equal to `expected`, so we don't need to check deeper;
+and can just report `check_equal` as passing.
 
 If either `==` or `≈` return true then so does this.
 The `kwargs` are passed on to `isapprox`

--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -27,16 +27,18 @@ end
 
 """
     _can_pass_early(actual, expected; kwargs...)
-Used to check if we actual is basically equal to expected, so we don't need to check deeper
+Used to check if we actual is basically equal to expected, so we don't need to check deeper.
 
-If either `==` then `isapprox` (if defined) return true then so does this.
+If either `==` or `≈` return true then so does this.
 The `kwargs` are passed on to `isapprox`
 """
 function _can_pass_early(actual, expected; kwargs...)
     actual == expected && return true
-    # use isapprox if such a method is defined (don't if it would error)
-    if applicable(isapprox, actual, expected)
+    try
         return isapprox(actual, expected; kwargs...)
+    catch err
+        # Might MethodError, might DimensionMismatch, might fail for some other reason
+        # we don't care, whatever errored it means we can't quit early
     end
     return false
 end

--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -25,9 +25,27 @@ for (T1, T2) in ((AbstractThunk, Any), (AbstractThunk, AbstractThunk), (Any, Abs
     end
 end
 
+"""
+    _can_pass_early(actual, expected; kwargs...)
+Used to check if we actual is basically equal to expected, so we don't need to check deeper
+
+If either `==` then `isapprox` (if defined) return true then so does this.
+The `kwargs` are passed on to `isapprox`
+"""
+function _can_pass_early(actual, expected; kwargs...)
+    actual == expected && return true
+    # use isapprox if such a method is defined (don't if it would error)
+    if applicable(isapprox, actual, expected)
+        return isapprox(actual, expected; kwargs...)
+    end
+    return false
+end
+
+
+
 
 function check_equal(actual::AbstractArray, expected::AbstractArray; kwargs...)
-    if actual == expected  # if equal then we don't need to be smarter
+    if _can_pass_early(actual, expected)
         @test true
     else
         @test eachindex(actual) == eachindex(expected)
@@ -38,7 +56,7 @@ function check_equal(actual::AbstractArray, expected::AbstractArray; kwargs...)
 end
 
 function check_equal(actual::Composite{P}, expected::Composite{P}; kwargs...) where P
-    if actual == expected  # if equal then we don't need to be smarter
+    if _can_pass_early(actual, expected)
         @test true
     else
         all_keys = union(keys(actual), keys(expected))
@@ -58,9 +76,9 @@ end
 
 # This catches comparisons of Composites and Tuples/NamedTuple
 # and gives a error messaage complaining about that
-check_equal(::C, expected::T) where {C<:Composite, T} = @test C === T
-check_equal(::T, expected::C) where {C<:Composite, T} = @test C === T
-
+const LegacyZygoteCompTypes = Union{Tuple,NamedTuple}
+check_equal(::C, expected::T) where {C<:Composite,T<:LegacyZygoteCompTypes} = @test C === T
+check_equal(::T, expected::C) where {C<:Composite,T<:LegacyZygoteCompTypes} = @test T === C
 
 check_equal(::Zero, x; kwargs...) = check_equal(zero(x), x; kwargs...)
 check_equal(x, ::Zero; kwargs...) = check_equal(x, zero(x); kwargs...)
@@ -68,7 +86,7 @@ check_equal(x::Zero, y::Zero; kwargs...) = @test true
 
 # Generic fallback, probably a tuple or something
 function check_equal(actual::A, expected::E; kwargs...) where {A, E}
-    if actual == expected  # if equal then we don't need to be smarter
+    if _can_pass_early(actual, expected)
         @test true
     else
         c_actual = collect(actual)

--- a/test/check_result.jl
+++ b/test/check_result.jl
@@ -1,3 +1,15 @@
+
+struct FakeNaturalDiffWithIsApprox  # For testing overloading isapprox(::Composite) works:
+    x
+end
+function Base.isapprox(c::Composite, d::FakeNaturalDiffWithIsApprox; kwargs...)
+    return isapprox(c.x, d.x, kwargs...)
+end
+function Base.isapprox(d::FakeNaturalDiffWithIsApprox, c::Composite; kwargs...)
+    return isapprox(c.x, d.x, kwargs...)
+end
+
+
 @testset "check_result.jl" begin
     @testset "_check_add!!_behavour" begin
         check = ChainRulesTestUtils._check_add!!_behavour
@@ -53,6 +65,15 @@
             check_equal(
                 Composite{typeof(T)}(a=1.0),
                 Composite{typeof(T)}(a=1.0+1e-10, b=Zero())
+            )
+
+            check_equal(
+                Composite{FakeNaturalDiffWithIsApprox}(; x=1.4),
+                FakeNaturalDiffWithIsApprox(1.4)
+            )
+            check_equal(
+                FakeNaturalDiffWithIsApprox(1.4),
+                Composite{FakeNaturalDiffWithIsApprox}(; x=1.4)
             )
         end
         @testset "negative case" begin


### PR DESCRIPTION
fixed https://github.com/invenia/BlockDiagonals.jl/issues/49
which was overloading `isapprox` to support compare natural and structural differentials
which was broken by https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/57/

I want to do more to support those without them overloading `isapprox`
