### PR TITLE
logabsdet test fix

### DIFF
--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -74,7 +74,7 @@ function check_equal(actual::Composite{P}, expected::Composite{P}; kwargs...) wh
 end
 
 function check_equal(
-    ::Composite{ActualPrimal}, expected::Composite{ExpectedPrimal}
+    ::Composite{ActualPrimal}, expected::Composite{ExpectedPrimal}; kwargs...
 ) where {ActualPrimal, ExpectedPrimal}
     # this will certainly fail as we have another dispatch for that, but this will give as
     # good error message
@@ -99,10 +99,10 @@ end
 check_equal(x, y::Composite; kwargs...) = check_equal(y, x; kwargs...)
 
 # This catches comparisons of Composites and Tuples/NamedTuple
-# and gives a error messaage complaining about that
+# and gives an error message complaining about that
 const LegacyZygoteCompTypes = Union{Tuple,NamedTuple}
-check_equal(::C, expected::T) where {C<:Composite,T<:LegacyZygoteCompTypes} = @test C === T
-check_equal(::T, expected::C) where {C<:Composite,T<:LegacyZygoteCompTypes} = @test T === C
+check_equal(::C, ::T; kwargs...) where {C<:Composite,T<:LegacyZygoteCompTypes} = @test C === T
+check_equal(::T, ::C; kwargs...) where {C<:Composite,T<:LegacyZygoteCompTypes} = @test T === C
 
 # Generic fallback, probably a tuple or something
 function check_equal(actual::A, expected::E; kwargs...) where {A, E}

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -97,13 +97,15 @@ function _make_jvp_call(fdm, f, xs, ẋs, ignores)
     ignores = collect(ignores)
     all(ignores) && return ntuple(_->nothing, length(xs))
     sigargs = zip(xs[.!ignores], ẋs[.!ignores])
-    return to_composite(jvp(fdm, f2, sigargs...))
+    return _maybe_fix_to_composite(jvp(fdm, f2, sigargs...))
 end
 
-# remove after https://github.com/JuliaDiff/FiniteDifferences.jl/issues/97
-to_composite(x::Tuple) = Composite{typeof(x)}(x...)
-to_composite(x::NamedTuple) = Composite{typeof(x)}(;x...)
-to_composite(x) = x
+# TODO: remove after https://github.com/JuliaDiff/FiniteDifferences.jl/issues/97
+# For functions which return a tuple, FD returns a tuple to represent the differential. Tuple
+# is not a natural differential, because it doesn't overload +, so make it a Composite.
+_maybe_fix_to_composite(x::Tuple) = Composite{typeof(x)}(x...)
+_maybe_fix_to_composite(x::NamedTuple) = Composite{typeof(x)}(;x...)
+_maybe_fix_to_composite(x) = x
 
 """
     test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1), fkwargs=NamedTuple(), check_inferred=true, kwargs...)

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -97,8 +97,13 @@ function _make_jvp_call(fdm, f, xs, ẋs, ignores)
     ignores = collect(ignores)
     all(ignores) && return ntuple(_->nothing, length(xs))
     sigargs = zip(xs[.!ignores], ẋs[.!ignores])
-    return jvp(fdm, f2, sigargs...)
+    return to_composite(jvp(fdm, f2, sigargs...))
 end
+
+# remove after https://github.com/JuliaDiff/FiniteDifferences.jl/issues/97
+to_composite(x::Tuple) = Composite{typeof(x)}(x...)
+to_composite(x::NamedTuple) = Composite{typeof(x)}(;x...)
+to_composite(x) = x
 
 """
     test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1), fkwargs=NamedTuple(), check_inferred=true, kwargs...)

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -251,8 +251,7 @@ end
         end
     end
 
-    @testset "function with tuple output" begin
-        # key is that backing type of Composite =/= natural differential
+    @testset "tuple output (backing type of Composite =/= natural differential)" begin
         tuple_out(x) = return (x, 1.0) # i.e. (x, 1.0) and not (x, x)
         function ChainRulesCore.frule((_, dx), ::typeof(tuple_out), x)
             Ω = tuple_out(x)

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -251,6 +251,17 @@ end
         end
     end
 
+    @testset "function with tuple output" begin
+        # key is that backing type of Composite =/= natural differential
+        tuple_out(x) = return (x, 1.0) # i.e. (x, 1.0) and not (x, x)
+        function ChainRulesCore.frule((_, dx), ::typeof(tuple_out), x)
+            Ω = tuple_out(x)
+            ∂Ω = Composite{typeof(Ω)}(dx, Zero())
+            return Ω, ∂Ω
+        end
+        frule_test(tuple_out, (2.0, 1))
+    end
+
     @testset "ignoring arguments" begin
         fsymtest(x, s::Symbol) = x
         ChainRulesCore.frule((_, Δx, _), ::typeof(fsymtest), x, s) = (x, Δx)


### PR DESCRIPTION
Closes https://github.com/JuliaDiff/ChainRulesCore.jl/issues/266

There were two issues:
1) missing `;kwargs` causing the wrong method to dispatch
2) finite differencing returns a Tuple for functions which output a Tuple 