### PR TITLE
Fix rrule test on tuples

### DIFF
--- a/src/testers.jl
+++ b/src/testers.jl
@@ -70,7 +70,7 @@ function _make_j′vp_call(fdm, f, ȳ, xs, ignores)
     @assert length(fd) == length(arginds)
 
     for (dx, ind) in zip(fd, arginds)
-        args[ind] = dx
+        args[ind] = _maybe_fix_to_composite(dx)
     end
     return (args...,)
 end


### PR DESCRIPTION
[These tests](https://github.com/JuliaDiff/ChainRulesTestUtils.jl/blob/master/test/testers.jl#L250) were failing even after  #87 

CI being broken seems to have let a bunch of stuff slip through
