### PR TITLE
Fix docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,5 @@ ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.23"
+Documenter = "0.26"
+julia = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,4 +14,5 @@ makedocs(
 const repo = "github.com/JuliaDiff/ChainRulesTestUtils.jl.git"
 deploydocs(
     repo=repo,
+    pushpreview=true,
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,23 +12,6 @@ makedocs(
 )
 
 const repo = "github.com/JuliaDiff/ChainRulesTestUtils.jl.git"
-const PR = get(ENV, "TRAVIS_PULL_REQUEST", "false")
-if PR == "false"
-    # Normal case, only deploy docs if merging to master or release tagged
-    deploydocs(repo=repo)
-else
-    @info "Deploying review docs for PR #$PR"
-    # TODO: remove most of this once https://github.com/JuliaDocs/Documenter.jl/issues/1131 is resolved
-
-    # Overwrite Documenter's function for generating the versions.js file
-    foreach(Base.delete_method, methods(Documenter.Writers.HTMLWriter.generate_version_file))
-    Documenter.Writers.HTMLWriter.generate_version_file(_, _) = nothing
-    # Overwrite necessary environment variables to trick Documenter to deploy
-    ENV["TRAVIS_PULL_REQUEST"] = "false"
-    ENV["TRAVIS_BRANCH"] = "master"
-
-    deploydocs(
-        devurl="preview-PR$(PR)",
-        repo=repo,
-    )
-end
+deploydocs(
+    repo=repo,
+)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,5 +14,5 @@ makedocs(
 const repo = "github.com/JuliaDiff/ChainRulesTestUtils.jl.git"
 deploydocs(
     repo=repo,
-    pushpreview=true,
+    push_preview=true,
 )


### PR DESCRIPTION
This fixes the issue of absent doc pages, the reason being `docs/make.jl` using Travis-specific code