### PR TITLE
rename internal use of  behavour to behaviour

### DIFF
--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -120,7 +120,7 @@ end
 
 
 """
-_check_add!!_behavour(acc, val)
+_check_add!!_behaviour(acc, val)
 
 This checks that `acc + val` is the same as `add!!(acc, val)`.
 It matters primarily for types that overload `add!!` such as `InplaceableThunk`s.
@@ -130,10 +130,12 @@ It matters primarily for types that overload `add!!` such as `InplaceableThunk`s
 
 `kwargs` are all passed on to isapprox
 """
-function _check_add!!_behavour(acc, val; kwargs...)
+function _check_add!!_behaviour(acc, val; kwargs...)
     # Note, we don't test that `acc` is actually mutated because it doesn't have to be
     # e.g. if it is immutable. We do test the `add!!` return value.
     # That is what people should rely on. The mutation is just to save allocations.
     acc_mutated = deepcopy(acc)  # prevent this test changing others
     check_equal(add!!(acc_mutated, val), acc + val; kwargs...)
 end
+
+@deprecate _check_add!!_behavour(acc, val; kwargs...) _check_add!!_behaviour(acc, val; kwargs...)

--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -137,5 +137,3 @@ function _check_add!!_behaviour(acc, val; kwargs...)
     acc_mutated = deepcopy(acc)  # prevent this test changing others
     check_equal(add!!(acc_mutated, val), acc + val; kwargs...)
 end
-
-@deprecate _check_add!!_behavour(acc, val; kwargs...) _check_add!!_behaviour(acc, val; kwargs...)

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -221,7 +221,7 @@ function frule_test(f, xẋs::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm=_fdm
     # No tangent is passed in to test accumlation, so generate one
     # See: https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/66
     acc = rand_tangent(Ω)
-    _check_add!!_behavour(acc, dΩ_ad; rtol=rtol, atol=atol, kwargs...)
+    _check_add!!_behaviour(acc, dΩ_ad; rtol=rtol, atol=atol, kwargs...)
 end
 
 
@@ -272,7 +272,7 @@ function rrule_test(f, ȳ, xx̄s::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm
 
             # The main test of the actual deriviative being correct:
             check_equal(x̄_ad, x̄_fd; isapprox_kwargs...)
-            _check_add!!_behavour(accumulated_x̄, x̄_ad; isapprox_kwargs...)
+            _check_add!!_behaviour(accumulated_x̄, x̄_ad; isapprox_kwargs...)
         end
     end
 

--- a/test/check_result.jl
+++ b/test/check_result.jl
@@ -28,7 +28,6 @@ end
             @thunk([2.0, 0.0]),
             X̄ -> (X̄[1] += 3.0; X̄),
         )))
-        @test_deprecated ChainRulesTestUtils._check_add!!_behavour(10.0, 2.0)
     end
 
 

--- a/test/check_result.jl
+++ b/test/check_result.jl
@@ -11,8 +11,8 @@ end
 
 
 @testset "check_result.jl" begin
-    @testset "_check_add!!_behavour" begin
-        check = ChainRulesTestUtils._check_add!!_behavour
+    @testset "_check_add!!_behaviour" begin
+        check = ChainRulesTestUtils._check_add!!_behaviour
 
         check(10.0, 2.0)
         check(11.0, Zero())
@@ -28,6 +28,7 @@ end
             @thunk([2.0, 0.0]),
             X̄ -> (X̄[1] += 3.0; X̄),
         )))
+        @test_deprecated ChainRulesTestUtils._check_add!!_behavour(10.0, 2.0)
     end
 
 


### PR DESCRIPTION
"behavour" seems to be a typo here, I added a deprecation to avoid breaking external code relying on this