### PR TITLE
Increase FiniteDifferences to v0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,5 +13,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 ChainRulesCore = "0.9.13"
 Compat = "3"
-FiniteDifferences = "0.11.2"
+FiniteDifferences = "0.12"
 julia = "1"

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -9,7 +9,7 @@ using LinearAlgebra
 using Random
 using Test
 
-const _fdm = central_fdm(5, 1)
+const _fdm = central_fdm(5, 1; max_range=1e-2)
 
 export TestIterator
 export check_equal, test_scalar, frule_test, rrule_test, generate_well_conditioned_matrix


### PR DESCRIPTION
This PR also sets `max_range` of `_fdm` to `1e-2` to prevent tests from accidentally failing due to singularities.

See also https://github.com/JuliaDiff/ChainRules.jl/pull/341.