### PR TITLE
Automatically provide tangents

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
+          version: '1.5'
       - uses: julia-actions/julia-docdeploy@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.6.2"
+version = "0.6.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -122,16 +122,16 @@ relu at -0.5, with cotangent 1.0 |    4      4
 [`frule_test`](@ref) and [`rrule_test`](@ref) allow you to specify the tangents used for testing.
 This is done by passing in `x ⊢ Δx`, where `x` is the primal and `Δx` is the tangent, in the place of the primal inputs.
 If this is not done the tangent will be automatically generated via [`rand_tangent`](@ref).
-A special-case of this is that if you specify it as `x ⊢ nothing` then finite differencing will not be used on that input.
+A special case of this is that if you specify it as `x ⊢ nothing` then finite differencing will not be used on that input.
 Similarly, by setting the `output_tangent` keyword argument, you can specify the tangent for the primal output.
 
 This can be useful when the default provided [`rand_tangent`](@ref) doesn't produce the desired tangent for your type.
 For example the default tangent for an `Int` is `DoesNotExist()`.
-Which is correct e.g. when the Int represents a descrete integer like in indexing.
-But if you are testing something where the `Int` actually is a special-case of real number, then you would want specify the tangent as a `Float64`.
+Which is correct e.g. when the `Int` represents a discrete integer like in indexing.
+But if you are testing something where the `Int` is actually a special case of a real number, then you would want to specify the tangent as a `Float64`.
 
 Care must be taken when manually specifying tangents.
-In particular when specifying the input tangents to [`test_frule`](@ref) and the output tangent to [`test_rrule`](@ref).
+In particular, when specifying the input tangents to [`test_frule`](@ref) and the output tangent to [`test_rrule`](@ref).
 As these tangents are used to seed the derivative computation.
 Inserting inappropriate zeros can thus hide errors.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,7 +58,7 @@ Keep this in mind when testing discontinuous rules for functions like [ReLU](htt
 ```jldoctest ex; output = false
 using ChainRulesTestUtils
 
-test_frule(two2three, 3.33, -7.77))
+test_frule(two2three, 3.33, -7.77)
 # output
 Test Summary:                    | Pass  Total
 Tuple{Float64,Float64,Float64}.1 |    1      1
@@ -75,7 +75,7 @@ Test Passed
 The call will test the `rrule` for function `f` at the point `x`, and similarly to `frule` some rules should be tested at multiple points in the domain.
 
 ```jldoctest ex; output = false
-test_rrule(two2three, 3.33, -7.77))
+test_rrule(two2three, 3.33, -7.77)
 # output
 Test Summary:                      |
 Don't thunk only non_zero argument | No tests
@@ -119,13 +119,13 @@ relu at -0.5, with cotangent 1.0 |    4      4
 ```
 
 ## Specifying Tangents
-[`frule_test`](@ref) and [`rrule_test`](@ref) allow you to specify the tangents used for testing.
+[`test_frule`](@ref) and [`test_rrule`](@ref) allow you to specify the tangents used for testing.
 This is done by passing in `x ⊢ Δx`, where `x` is the primal and `Δx` is the tangent, in the place of the primal inputs.
-If this is not done the tangent will be automatically generated via [`rand_tangent`](@ref).
+If this is not done the tangent will be automatically generated via [`ChainRulesTestUtils.rand_tangent`](@ref).
 A special case of this is that if you specify it as `x ⊢ nothing` then finite differencing will not be used on that input.
 Similarly, by setting the `output_tangent` keyword argument, you can specify the tangent for the primal output.
 
-This can be useful when the default provided [`rand_tangent`](@ref) doesn't produce the desired tangent for your type.
+This can be useful when the default provided [`ChainRulesTestUtils.rand_tangent`](@ref) doesn't produce the desired tangent for your type.
 For example the default tangent for an `Int` is `DoesNotExist()`.
 Which is correct e.g. when the `Int` represents a discrete integer like in indexing.
 But if you are testing something where the `Int` is actually a special case of a real number, then you would want to specify the tangent as a `Float64`.
@@ -165,4 +165,8 @@ which should have passed the test.
 ```@autodocs
 Modules = [ChainRulesTestUtils]
 Private = false
+```
+
+```@docs
+ChainRulesTestUtils.rand_tangent
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -45,24 +45,20 @@ end
 
 ```
 
-The [`frule_test`](@ref)/[`rrule_test`](@ref) helper function compares the `frule`/`rrule` outputs
+The [`test_frule`](@ref)/[`test_rrule`](@ref) helper function compares the `frule`/`rrule` outputs
 to the gradients obtained by finite differencing.
 They can be used for any type and number of inputs and outputs.
 
 ### Testing the `frule`
 
-[`frule_test`](@ref) takes in the function `f` and tuples `(x, ẋ)` for each function argument `x`.
+[`test_frule`](@ref) takes in the function `f` and the primal input `x`.
 The call will test the `frule` for function `f` at the point `x` in the domain.
 Keep this in mind when testing discontinuous rules for functions like [ReLU](https://en.wikipedia.org/wiki/Rectifier_(neural_networks)), which should ideally be tested at both `x` being above and below zero.
-Additionally, choosing `ẋ` in an unfortunate way (e.g. as zeros) could hide underlying problems with the defined `frule`.
 
 ```jldoctest ex; output = false
 using ChainRulesTestUtils
 
-x1, x2 = (3.33, -7.77)
-ẋ1, ẋ2 = (rand(), rand())
-
-frule_test(two2three, (x1, ẋ1), (x2, ẋ2))
+test_frule(two2three, 3.33, -7.77))
 # output
 Test Summary:                    | Pass  Total
 Tuple{Float64,Float64,Float64}.1 |    1      1
@@ -75,17 +71,11 @@ Test Passed
 
 ### Testing the `rrule`
 
-[`rrule_test`](@ref) takes in the function `f`, sensitivities of the function outputs `ȳ`, and tuples `(x, x̄)` for each function argument `x`.
-`x̄` is the accumulated adjoint which can be set arbitrarily.
+[`test_rrule`](@ref) takes in the function `f`, and primal inputsr `x`.
 The call will test the `rrule` for function `f` at the point `x`, and similarly to `frule` some rules should be tested at multiple points in the domain.
-Choosing `ȳ` in an unfortunate way (e.g. as zeros) could hide underlying problems with the `rrule`. 
+
 ```jldoctest ex; output = false
-x1, x2 = (3.33, -7.77)
-x̄1, x̄2 = (rand(), rand())
-ȳs = (rand(), rand(), rand())
-
-rrule_test(two2three, ȳs, (x1, x̄1), (x2, x̄2))
-
+test_rrule(two2three, 3.33, -7.77))
 # output
 Test Summary:                      |
 Don't thunk only non_zero argument | No tests
@@ -128,13 +118,30 @@ Test Summary:                    | Pass  Total
 relu at -0.5, with cotangent 1.0 |    4      4
 ```
 
+## Specifying Tangents
+[`frule_test`](@ref) and [`rrule_test`](@ref) allow you to specify the tangents used for testing.
+This is done by passing in `x ⊢ Δx`, where `x` is the primal and `Δx` is the tangent, in the place of the primal inputs.
+If this is not done the tangent will be automatically generated via [`rand_tangent`](@ref).
+A special-case of this is that if you specify it as `x ⊢ nothing` then finite differencing will not be used on that input.
+Similarly, by setting the `output_tangent` keyword argument, you can specify the tangent for the primal output.
+
+This can be useful when the default provided [`rand_tangent`](@ref) doesn't produce the desired tangent for your type.
+For example the default tangent for an `Int` is `DoesNotExist()`.
+Which is correct e.g. when the Int represents a descrete integer like in indexing.
+But if you are testing something where the `Int` actually is a special-case of real number, then you would want specify the tangent as a `Float64`.
+
+Care must be taken when manually specifying tangents.
+In particular when specifying the input tangents to [`test_frule`](@ref) and the output tangent to [`test_rrule`](@ref).
+As these tangents are used to seed the derivative computation.
+Inserting inappropriate zeros can thus hide errors.
+
 ## Custom finite differencing
 
 If a package is using a custom finite differencing method of testing the `frule`s and `rrule`s, `check_equal` function provides a convenient way of comparing [various types](https://www.juliadiff.org/ChainRulesCore.jl/dev/design/many_differentials.html#Design-Notes:-The-many-to-many-relationship-between-differential-types-and-primal-types.) of differentials.
 
 It is effectively `(a, b) -> @test isapprox(a, b)`, but it preprocesses `thunk`s and `ChainRules` differential types `Zero()`, `DoesNotExist()`, and `Composite`, such that the error messages are helpful.
 
-For example, 
+For example,
 ```julia
 check_equal((@thunk 2*2.0), 4.1)
 ```

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -13,7 +13,7 @@ const _fdm = central_fdm(5, 1; max_range=1e-2)
 
 export TestIterator
 export check_equal, test_scalar, test_frule, test_rrule, generate_well_conditioned_matrix
-export Auto, ⟂
+export Auto, ⊢
 
 
 include("generate_tangent.jl")

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -13,7 +13,7 @@ const _fdm = central_fdm(5, 1; max_range=1e-2)
 
 export TestIterator
 export check_equal, test_scalar, test_frule, test_rrule, generate_well_conditioned_matrix
-export Auto, ⊢
+export ⊢
 
 
 include("generate_tangent.jl")

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -12,7 +12,8 @@ using Test
 const _fdm = central_fdm(5, 1; max_range=1e-2)
 
 export TestIterator
-export check_equal, test_scalar, frule_test, rrule_test, generate_well_conditioned_matrix
+export check_equal, test_scalar, test_frule, test_rrule, generate_well_conditioned_matrix
+export Auto, ⟂
 
 
 include("generate_tangent.jl")

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -32,10 +32,10 @@ Base.isapprox(d_ad::Composite{P}, d_fd::Composite{Q}; kwargs...) where {P, Q} = 
 # From when primal and tangent was passed as a tuple
 @deprecate(
     rrule_test(f, ȳ, inputs::Tuple{Any,Any}...; kwargs...),
-    test_rrule(f, ((x ⟂ dx) for (x, dx) in inputs)...; output_tangent=ȳ, kwargs...)
+    test_rrule(f, ((x ⊢ dx) for (x, dx) in inputs)...; output_tangent=ȳ, kwargs...)
 )
 
 @deprecate(
     frule_test(f, inputs::Tuple{Any,Any}...; kwargs...),
-    test_frule(f, ((x ⟂ dx) for (x, dx) in inputs)...; kwargs...)
+    test_frule(f, ((x ⊢ dx) for (x, dx) in inputs)...; kwargs...)
 )

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -30,13 +30,12 @@ Base.isapprox(d_ad::Composite{P}, d_fd::Composite{Q}; kwargs...) where {P, Q} = 
 
 
 # From when primal and tangent was passed as a tuple
-# Until this is dropped, tangent will still manually need to be provided for tuple inputs
 @deprecate(
-    rrule_test(f, ȳ, inputs::Tuple{Any,Any}...; kwargs...)
-    rrule_test(f, ȳ, ((x ⟂ dx) for (x, dx) in inputs))...; kwargs...)
+    rrule_test(f, ȳ, inputs::Tuple{Any,Any}...; kwargs...),
+    test_rrule(f, ((x ⟂ dx) for (x, dx) in inputs)...; output_tangent=ȳ, kwargs...)
 )
 
 @deprecate(
-    frule_test(f, inputs::Tuple{Any,Any}...; kwargs...)
-    frule_test(f, ((x ⟂ dx) for (x, dx) in inputs))...; kwargs...)
+    frule_test(f, inputs::Tuple{Any,Any}...; kwargs...),
+    test_frule(f, ((x ⟂ dx) for (x, dx) in inputs)...; kwargs...)
 )

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -27,3 +27,16 @@ end
 
 # Must be for same primal
 Base.isapprox(d_ad::Composite{P}, d_fd::Composite{Q}; kwargs...) where {P, Q} = false
+
+
+# From when primal and tangent was passed as a tuple
+# Until this is dropped, tangent will still manually need to be provided for tuple inputs
+@deprecate(
+    rrule_test(f, ȳ, inputs::Tuple{Any,Any}...; kwargs...)
+    rrule_test(f, ȳ, ((x ⟂ dx) for (x, dx) in inputs))...; kwargs...)
+)
+
+@deprecate(
+    frule_test(f, inputs::Tuple{Any,Any}...; kwargs...)
+    frule_test(f, ((x ⟂ dx) for (x, dx) in inputs))...; kwargs...)
+)

--- a/src/generate_tangent.jl
+++ b/src/generate_tangent.jl
@@ -1,4 +1,36 @@
 """
+    PrimalAndTangent
+
+A struct that represents a primal value paired with its tangent or cotangent.
+For conciseness we refer to both tangent and cotangent as "tangent".
+"""
+struct PrimalAndTangent{P,D}
+    primal::P
+    tangent::D
+end
+primal(p::PrimalAndTangent) = p.primal
+tangent(p::PrimalAndTangent) = p.tangent
+
+"""
+    primal ⟂ tangent
+
+Infix shorthand method to construct a `PrimalAndTangent`.
+"""
+const ⟂ = PrimalAndTangent
+
+"""
+    auto_primal_and_tangent(primal; rng=Random.GLOBAL_RNG)
+    auto_primal_and_tangent(::PrimalAndTangent; rng=Random.GLOBAL_RNG)
+
+Convience constructor for `PrimalAndTangent` where the primal is provided
+
+This function is idempotent. If you pass it a `PrimalAndTangent` it doesn't change it.
+"""
+auto_primal_and_tangent(primal; rng=Random.GLOBAL_RNG) = primal ⟂ rand_tangent(rng primal)
+auto_primal_and_tangent(both::PrimalAndTangent; kwargs...) = both
+
+
+"""
     rand_tangent([rng::AbstractRNG,] x)
 
 Returns a randomly generated tangent vector appropriate for the primal value `x`.

--- a/src/generate_tangent.jl
+++ b/src/generate_tangent.jl
@@ -38,11 +38,6 @@ This function is idempotent. If you pass it a `PrimalAndTangent` it doesn't chan
 """
 auto_primal_and_tangent(primal; rng=Random.GLOBAL_RNG) = primal ⊢ rand_tangent(rng, primal)
 auto_primal_and_tangent(both::PrimalAndTangent; kwargs...) = both
-function auto_primal_and_tangent(auto::PrimalAndTangent{<:Any,Auto}; kwargs...)
-    # If the tangent is a Auto() marker, just use the primal to generate
-    return auto_primal_and_tangent(primal(auto); kwargs...)
-end
-
 
 """
     rand_tangent([rng::AbstractRNG,] x)

--- a/src/generate_tangent.jl
+++ b/src/generate_tangent.jl
@@ -1,4 +1,13 @@
 """
+    Auto()
+
+Use this in the place of a tangent/cotangent in [`test_frule`](@ref) or
+[`test_rrule`](@ref) to have that tangent/cotangent generated automatically based on the
+primal. Uses [`rand_tangent`](@ref)
+"""
+struct Auto end
+
+"""
     PrimalAndTangent
 
 A struct that represents a primal value paired with its tangent or cotangent.
@@ -26,8 +35,12 @@ Convience constructor for `PrimalAndTangent` where the primal is provided
 
 This function is idempotent. If you pass it a `PrimalAndTangent` it doesn't change it.
 """
-auto_primal_and_tangent(primal; rng=Random.GLOBAL_RNG) = primal ⟂ rand_tangent(rng primal)
+auto_primal_and_tangent(primal; rng=Random.GLOBAL_RNG) = primal ⟂ rand_tangent(rng, primal)
 auto_primal_and_tangent(both::PrimalAndTangent; kwargs...) = both
+function auto_primal_and_tangent(auto::PrimalAndTangent{<:Any,Auto}; kwargs...)
+    # If the tangent is a Auto() marker, just use the primal to generate
+    return auto_primal_and_tangent(primal(auto); kwargs...)
+end
 
 
 """

--- a/src/generate_tangent.jl
+++ b/src/generate_tangent.jl
@@ -24,6 +24,7 @@ tangent(p::PrimalAndTangent) = p.tangent
     primal ⊢ tangent
 
 Infix shorthand method to construct a `PrimalAndTangent`.
+Enter via `\\vdash` + tab on supporting editors.
 """
 const ⊢ = PrimalAndTangent
 

--- a/src/generate_tangent.jl
+++ b/src/generate_tangent.jl
@@ -21,11 +21,11 @@ primal(p::PrimalAndTangent) = p.primal
 tangent(p::PrimalAndTangent) = p.tangent
 
 """
-    primal ⟂ tangent
+    primal ⊢ tangent
 
 Infix shorthand method to construct a `PrimalAndTangent`.
 """
-const ⟂ = PrimalAndTangent
+const ⊢ = PrimalAndTangent
 
 """
     auto_primal_and_tangent(primal; rng=Random.GLOBAL_RNG)
@@ -35,7 +35,7 @@ Convience constructor for `PrimalAndTangent` where the primal is provided
 
 This function is idempotent. If you pass it a `PrimalAndTangent` it doesn't change it.
 """
-auto_primal_and_tangent(primal; rng=Random.GLOBAL_RNG) = primal ⟂ rand_tangent(rng, primal)
+auto_primal_and_tangent(primal; rng=Random.GLOBAL_RNG) = primal ⊢ rand_tangent(rng, primal)
 auto_primal_and_tangent(both::PrimalAndTangent; kwargs...) = both
 function auto_primal_and_tangent(auto::PrimalAndTangent{<:Any,Auto}; kwargs...)
     # If the tangent is a Auto() marker, just use the primal to generate

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -26,7 +26,7 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
     Δx = one(z)
     @testset "$f at $z, with tangent $Δx" begin
         # check ∂u_∂x and (if Ω is complex) ∂v_∂x via forward mode
-        frule_test(f, (z, Δx); rule_test_kwargs...)
+        frule_test(f, z ⟂ Δx; rule_test_kwargs...)
         if z isa Complex
             # check that same tangent is produced for tangent 1.0 and 1.0 + 0.0im
             _, real_tangent = frule((Zero(), real(Δx)), f, z; fkwargs...)
@@ -38,7 +38,7 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
         Δy = one(z) * im
         @testset "$f at $z, with tangent $Δy" begin
             # check ∂u_∂y and (if Ω is complex) ∂v_∂y via forward mode
-            frule_test(f, (z, Δy); rule_test_kwargs...)
+            frule_test(f, z ⟂ Δy; rule_test_kwargs...)
         end
     end
 
@@ -46,7 +46,7 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
     Δu = one(Ω)
     @testset "$f at $z, with cotangent $Δu" begin
         # check ∂u_∂x and (if z is complex) ∂u_∂y via reverse mode
-        rrule_test(f, Δu, (z, Δx); rule_test_kwargs...)
+        rrule_test(f, Δu, z ⟂ Δx; rule_test_kwargs...)
         if Ω isa Complex
             # check that same cotangent is produced for cotangent 1.0 and 1.0 + 0.0im
             _, back = rrule(f, z)
@@ -59,19 +59,20 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
         Δv = one(Ω) * im
         @testset "$f at $z, with cotangent $Δv" begin
             # check ∂v_∂x and (if z is complex) ∂v_∂y via reverse mode
-            rrule_test(f, Δv, (z, Δx); rule_test_kwargs...)
+            rrule_test(f, Δv, z ⟂ Δx; rule_test_kwargs...)
         end
     end
 end
 
 
 """
-    frule_test(f, (x, ẋ)...; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1), fkwargs=NamedTuple(), check_inferred=true, kwargs...)
+    frule_test(f, inputs...; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1), fkwargs=NamedTuple(), check_inferred=true, kwargs...)
 
 # Arguments
 - `f`: Function for which the `frule` should be tested.
-- `x`: input at which to evaluate `f` (should generally be set to an arbitary point in the domain).
-- `ẋ`: differential w.r.t. `x` (should generally be set randomly).
+- `inputs` either the primal inputs `x`, or primals and their tangents: `x ⟂ ẋ`
+   - `x`: input at which to evaluate `f` (should generally be set to an arbitary point in the domain).
+   - `ẋ`: differential w.r.t. `x`, will be generated automatically if not provided
 
 Non-differentiable arguments, such as indices, should have `ẋ` set as `nothing`.
 `fkwargs` are passed to `f` as keyword arguments.
@@ -79,14 +80,15 @@ If `check_inferred=true`, then the inferrability of the `frule` is checked, as l
 is itself inferrable.
 All remaining keyword arguments are passed to `isapprox`.
 """
-function frule_test(f, xẋs::Tuple{Any, Any}...; rtol::Real=1e-9, atol::Real=1e-9, fdm=_fdm, fkwargs::NamedTuple=NamedTuple(), check_inferred::Bool=true, kwargs...)
+function frule_test(f, inputs...; rtol::Real=1e-9, atol::Real=1e-9, fdm=_fdm, fkwargs::NamedTuple=NamedTuple(), check_inferred::Bool=true, kwargs...)
     # To simplify some of the calls we make later lets group the kwargs for reuse
     isapprox_kwargs = (; rtol=rtol, atol=atol, kwargs...)
 
     _ensure_not_running_on_functor(f, "frule_test")
 
-    xs = first.(xẋs)
-    ẋs = last.(xẋs)
+    xẋs = auto_primal_and_tangent.(inputs)
+    xs = primal.(xẋs)
+    ẋs = tangent.(xẋs)
     if check_inferred && _is_inferrable(f, deepcopy(xs)...; deepcopy(fkwargs)...)
         _test_inferred(frule, (NO_FIELDS, deepcopy(ẋs)...), f, deepcopy(xs)...; deepcopy(fkwargs)...)
     end
@@ -110,14 +112,15 @@ end
 
 
 """
-    rrule_test(f, ȳ, (x, x̄)...; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1), fkwargs=NamedTuple(), check_inferred=true, kwargs...)
+    rrule_test(f, ȳ, inputs...; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1), fkwargs=NamedTuple(), check_inferred=true, kwargs...)
 
 # Arguments
 - `f`: Function to which rule should be applied.
 - `ȳ`: adjoint w.r.t. output of `f` (should generally be set randomly).
   Should be same structure as `f(x)` (so if multiple returns should be a tuple)
-- `x`: input at which to evaluate `f` (should generally be set to an arbitary point in the domain).
-- `x̄`: currently accumulated adjoint (should generally be set randomly).
+- `inputs` either the primal inputs `x`, or primals and their tangents: `x ⟂ ẋ`
+    - `x`: input at which to evaluate `f` (should generally be set to an arbitary point in the domain).
+    - `x̄`: currently accumulated cotangent, will be generated automatically if not provided
 
 Non-differentiable arguments, such as indices, should have `x̄` set as `nothing`.
 `fkwargs` are passed to `f` as keyword arguments.
@@ -125,15 +128,16 @@ If `check_inferred=true`, then the inferrability of the `rrule` is checked — i
 itself inferrable — along with the inferrability of the pullback it returns.
 All remaining keyword arguments are passed to `isapprox`.
 """
-function rrule_test(f, ȳ, xx̄s::Tuple{Any, Any}...; rtol::Real=1e-9, atol::Real=1e-9, fdm=_fdm, check_inferred::Bool=true, fkwargs::NamedTuple=NamedTuple(), kwargs...)
+function rrule_test(f, ȳ, inputs...; rtol::Real=1e-9, atol::Real=1e-9, fdm=_fdm, check_inferred::Bool=true, fkwargs::NamedTuple=NamedTuple(), kwargs...)
     # To simplify some of the calls we make later lets group the kwargs for reuse
     isapprox_kwargs = (; rtol=rtol, atol=atol, kwargs...)
 
     _ensure_not_running_on_functor(f, "rrule_test")
 
     # Check correctness of evaluation.
-    xs = first.(xx̄s)
-    accumulated_x̄ = last.(xx̄s)
+    xx̄s = auto_primal_and_tangent.(inputs)
+    xs = primal.(xx̄s)
+    accumulated_x̄ = tangent.(xx̄s)
     if check_inferred && _is_inferrable(f, xs...; fkwargs...)
         _test_inferred(rrule, f, xs...; fkwargs...)
     end

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -116,7 +116,7 @@ function test_frule(
     dΩ_fd = _make_jvp_call(fdm, (xs...) -> f(deepcopy(xs)...; deepcopy(fkwargs)...), Ω, xs, ẋs, ẋs_is_ignored)
     check_equal(dΩ_ad, dΩ_fd; isapprox_kwargs...)
 
-    acc = tangent(auto_primal_and_tangent(Ω ⊢ output_tangent))
+    acc = output_tangent isa Auto ? rand_tangent(Ω) : output_tangent
     _check_add!!_behaviour(acc, dΩ_ad; rtol=rtol, atol=atol, kwargs...)
 end
 
@@ -167,7 +167,7 @@ function test_rrule(
     y = f(xs...; fkwargs...)
     check_equal(y_ad, y; isapprox_kwargs...)  # make sure primal is correct
 
-    ȳ = tangent(auto_primal_and_tangent(y ⊢ output_tangent))
+    ȳ = output_tangent isa Auto ? rand_tangent(y) : output_tangent
 
     check_inferred && _test_inferred(pullback, ȳ)
     ∂s = pullback(ȳ)

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -26,7 +26,7 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
     Δx = one(z)
     @testset "$f at $z, with tangent $Δx" begin
         # check ∂u_∂x and (if Ω is complex) ∂v_∂x via forward mode
-        frule_test(f, z ⊢ Δx; rule_test_kwargs...)
+        test_frule(f, z ⊢ Δx; rule_test_kwargs...)
         if z isa Complex
             # check that same tangent is produced for tangent 1.0 and 1.0 + 0.0im
             _, real_tangent = frule((Zero(), real(Δx)), f, z; fkwargs...)
@@ -38,7 +38,7 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
         Δy = one(z) * im
         @testset "$f at $z, with tangent $Δy" begin
             # check ∂u_∂y and (if Ω is complex) ∂v_∂y via forward mode
-            frule_test(f, z ⊢ Δy; rule_test_kwargs...)
+            test_frule(f, z ⊢ Δy; rule_test_kwargs...)
         end
     end
 
@@ -46,7 +46,7 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
     Δu = one(Ω)
     @testset "$f at $z, with cotangent $Δu" begin
         # check ∂u_∂x and (if z is complex) ∂u_∂y via reverse mode
-        rrule_test(f, Δu, z ⊢ Δx; rule_test_kwargs...)
+        test_rrule(f, z ⊢ Δx; output_tangent=Δu, rule_test_kwargs...)
         if Ω isa Complex
             # check that same cotangent is produced for cotangent 1.0 and 1.0 + 0.0im
             _, back = rrule(f, z)
@@ -59,7 +59,7 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
         Δv = one(Ω) * im
         @testset "$f at $z, with cotangent $Δv" begin
             # check ∂v_∂x and (if z is complex) ∂v_∂y via reverse mode
-            rrule_test(f, Δv, z ⊢ Δx; rule_test_kwargs...)
+            test_rrule(f, z ⊢ Δx; output_tangent=Δv,  rule_test_kwargs...)
         end
     end
 end

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -116,9 +116,7 @@ function test_frule(
     dΩ_fd = _make_jvp_call(fdm, (xs...) -> f(deepcopy(xs)...; deepcopy(fkwargs)...), Ω, xs, ẋs, ẋs_is_ignored)
     check_equal(dΩ_ad, dΩ_fd; isapprox_kwargs...)
 
-    # No tangent is passed in to test accumlation, so generate one
-    # See: https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/66
-    acc = rand_tangent(Ω)
+    acc = tangent(auto_primal_and_tangent(Ω ⊢ output_tangent))
     _check_add!!_behaviour(acc, dΩ_ad; rtol=rtol, atol=atol, kwargs...)
 end
 

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -26,7 +26,7 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
     Δx = one(z)
     @testset "$f at $z, with tangent $Δx" begin
         # check ∂u_∂x and (if Ω is complex) ∂v_∂x via forward mode
-        frule_test(f, z ⟂ Δx; rule_test_kwargs...)
+        frule_test(f, z ⊢ Δx; rule_test_kwargs...)
         if z isa Complex
             # check that same tangent is produced for tangent 1.0 and 1.0 + 0.0im
             _, real_tangent = frule((Zero(), real(Δx)), f, z; fkwargs...)
@@ -38,7 +38,7 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
         Δy = one(z) * im
         @testset "$f at $z, with tangent $Δy" begin
             # check ∂u_∂y and (if Ω is complex) ∂v_∂y via forward mode
-            frule_test(f, z ⟂ Δy; rule_test_kwargs...)
+            frule_test(f, z ⊢ Δy; rule_test_kwargs...)
         end
     end
 
@@ -46,7 +46,7 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
     Δu = one(Ω)
     @testset "$f at $z, with cotangent $Δu" begin
         # check ∂u_∂x and (if z is complex) ∂u_∂y via reverse mode
-        rrule_test(f, Δu, z ⟂ Δx; rule_test_kwargs...)
+        rrule_test(f, Δu, z ⊢ Δx; rule_test_kwargs...)
         if Ω isa Complex
             # check that same cotangent is produced for cotangent 1.0 and 1.0 + 0.0im
             _, back = rrule(f, z)
@@ -59,7 +59,7 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
         Δv = one(Ω) * im
         @testset "$f at $z, with cotangent $Δv" begin
             # check ∂v_∂x and (if z is complex) ∂v_∂y via reverse mode
-            rrule_test(f, Δv, z ⟂ Δx; rule_test_kwargs...)
+            rrule_test(f, Δv, z ⊢ Δx; rule_test_kwargs...)
         end
     end
 end
@@ -70,7 +70,7 @@ end
 
 # Arguments
 - `f`: Function for which the `frule` should be tested.
-- `inputs` either the primal inputs `x`, or primals and their tangents: `x ⟂ ẋ`
+- `inputs` either the primal inputs `x`, or primals and their tangents: `x ⊢ ẋ`
    - `x`: input at which to evaluate `f` (should generally be set to an arbitary point in the domain).
    - `ẋ`: differential w.r.t. `x`, will be generated automatically if not provided
      Non-differentiable arguments, such as indices, should have `ẋ` set as `nothing`.
@@ -131,7 +131,7 @@ end
 - `f`: Function to which rule should be applied.
 - `ȳ`: adjoint w.r.t. output of `f` (should generally be set randomly).
   Should be same structure as `f(x)` (so if multiple returns should be a tuple)
-- `inputs` either the primal inputs `x`, or primals and their tangents: `x ⟂ ẋ`
+- `inputs` either the primal inputs `x`, or primals and their tangents: `x ⊢ ẋ`
     - `x`: input at which to evaluate `f` (should generally be set to an arbitary point in the domain).
     - `x̄`: currently accumulated cotangent, will be generated automatically if not provided
       Non-differentiable arguments, such as indices, should have `x̄` set as `nothing`.
@@ -171,7 +171,7 @@ function test_rrule(
     y = f(xs...; fkwargs...)
     check_equal(y_ad, y; isapprox_kwargs...)  # make sure primal is correct
 
-    ȳ = tangent(auto_primal_and_tangent(y ⟂ output_tangent))
+    ȳ = tangent(auto_primal_and_tangent(y ⊢ output_tangent))
 
     check_inferred && _test_inferred(pullback, ȳ)
     ∂s = pullback(ȳ)

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -66,7 +66,7 @@ end
 
 
 """
-    test_frule(f, inputs...; output_tangent=Auto(), fdm=central_fdm(5, 1), check_inferred=true, fkwargs::NamedTuple=NamedTuple(), rtol::Real=1e-9, atol::Real=1e-9, kwargs...)
+    test_frule(f, inputs...; kwargs...)
 
 # Arguments
 - `f`: Function for which the `frule` should be tested.
@@ -125,12 +125,10 @@ end
 
 
 """
-    test_rrule(f, ȳ, inputs...; output_tangent=Auto(), fdm=central_fdm(5, 1), check_inferred=true, fkwargs::NamedTuple=NamedTuple(), rtol::Real=1e-9, atol::Real=1e-9, kwargs...)
+    test_rrule(f, inputs...; kwargs...)
 
 # Arguments
 - `f`: Function to which rule should be applied.
-- `ȳ`: adjoint w.r.t. output of `f` (should generally be set randomly).
-  Should be same structure as `f(x)` (so if multiple returns should be a tuple)
 - `inputs` either the primal inputs `x`, or primals and their tangents: `x ⊢ ẋ`
     - `x`: input at which to evaluate `f` (should generally be set to an arbitary point in the domain).
     - `x̄`: currently accumulated cotangent, will be generated automatically if not provided

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -96,7 +96,7 @@ function test_frule(
     # To simplify some of the calls we make later lets group the kwargs for reuse
     isapprox_kwargs = (; rtol=rtol, atol=atol, kwargs...)
 
-    _ensure_not_running_on_functor(f, "frule_test")
+    _ensure_not_running_on_functor(f, "test_frule")
 
     xẋs = auto_primal_and_tangent.(inputs)
     xs = primal.(xẋs)
@@ -156,7 +156,7 @@ function test_rrule(
     # To simplify some of the calls we make later lets group the kwargs for reuse
     isapprox_kwargs = (; rtol=rtol, atol=atol, kwargs...)
 
-    _ensure_not_running_on_functor(f, "rrule_test")
+    _ensure_not_running_on_functor(f, "test_rrule")
 
     # Check correctness of evaluation.
     xx̄s = auto_primal_and_tangent.(inputs)

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -23,8 +23,6 @@
     end
 end
 
-
-
 @testset "old testers.jl" begin
     @testset "unary: identity(x)" begin
         function ChainRulesCore.frule((_, ẏ), ::typeof(identity), x)

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -22,3 +22,196 @@
         end
     end
 end
+
+
+
+@testset "old testers.jl" begin
+    @testset "unary: identity(x)" begin
+        function ChainRulesCore.frule((_, ẏ), ::typeof(identity), x)
+            return x, ẏ
+        end
+        function ChainRulesCore.rrule(::typeof(identity), x)
+            function identity_pullback(ȳ)
+                return (NO_FIELDS, ȳ)
+            end
+            return x, identity_pullback
+        end
+        @testset "frule_test" begin
+            frule_test(identity, (randn(), randn()))
+            frule_test(identity, (randn(4), randn(4)))
+        end
+        @testset "rrule_test" begin
+            rrule_test(identity, randn(), (randn(), randn()))
+            rrule_test(identity, randn(4), (randn(4), randn(4)))
+        end
+    end
+
+    @testset "test derivative conjugated in pullback" begin
+        ChainRulesCore.frule((_, Δx), ::typeof(sinconj), x) = (sin(x), cos(x) * Δx)
+
+        # define rrule using ChainRulesCore's v0.9.0 convention, conjugating the derivative
+        # in the rrule
+        function ChainRulesCore.rrule(::typeof(sinconj), x)
+            sinconj_pullback(ΔΩ) = (NO_FIELDS, conj(cos(x)) * ΔΩ)
+            return sin(x), sinconj_pullback
+        end
+
+        rrule_test(sinconj, randn(ComplexF64), (randn(ComplexF64), randn(ComplexF64)))
+        test_scalar(sinconj, randn(ComplexF64))
+    end
+
+    @testset "binary: fst(x, y)" begin
+        fst(x, y) = x
+        ChainRulesCore.frule((_, dx, dy), ::typeof(fst), x, y) = (x, dx)
+        function ChainRulesCore.rrule(::typeof(fst), x, y)
+            function fst_pullback(Δx)
+                return (NO_FIELDS, Δx, Zero())
+            end
+            return x, fst_pullback
+        end
+        @testset "frule_test" begin
+            frule_test(fst, (2, 4.0), (3, 5.0))
+            frule_test(fst, (randn(4), randn(4)), (randn(4), randn(4)))
+        end
+        @testset "rrule_test" begin
+            rrule_test(fst, rand(), (2.0, 4.0), (3.0, 5.0))
+            rrule_test(fst, randn(4), (randn(4), randn(4)), (randn(4), randn(4)))
+        end
+    end
+
+    @testset "single input, multiple output" begin
+        simo(x) = (x, 2x)
+        function ChainRulesCore.rrule(simo, x)
+            simo_pullback((a, b)) = (NO_FIELDS, a .+ 2 .* b)
+            return simo(x), simo_pullback
+        end
+        function ChainRulesCore.frule((_, ẋ), simo, x)
+            y = simo(x)
+            return y, Composite{typeof(y)}(ẋ, 2ẋ)
+        end
+
+        @testset "frule_test" begin
+            frule_test(simo, (randn(), randn()))  # on scalar
+            frule_test(simo, (randn(4), randn(4)))  # on array
+        end
+        @testset "rrule_test" begin
+            # note: we are pulling back tuples (could use Composites here instead)
+            rrule_test(simo, (randn(), rand()), (randn(), randn()))  # on scalar
+            rrule_test(simo, (randn(4), rand(4)), (randn(4), randn(4))) # on array
+        end
+    end
+
+
+    @testset "tuple input: first" begin
+        ChainRulesCore.frule((_, dx), ::typeof(first), xs::Tuple) = (first(xs), first(dx))
+        function ChainRulesCore.rrule(::typeof(first), x::Tuple)
+            function first_pullback(Δx)
+                return (NO_FIELDS, Composite{typeof(x)}(Δx, falses(length(x)-1)...))
+            end
+            return first(x), first_pullback
+        end
+
+        CTuple{N} = Composite{NTuple{N, Float64}}  # shorter for testing
+        @testset "frule_test" begin
+            frule_test(first, ((2.0, 3.0), CTuple{2}(4.0, 5.0)))
+            frule_test(first, (Tuple(randn(4)), CTuple{4}(randn(4)...)))
+        end
+        @testset "rrule_test" begin
+            rrule_test(first, 2.0, ((2.0, 3.0), CTuple{2}(4.0, 5.0)); check_inferred = false)
+            rrule_test(first, randn(), (Tuple(randn(4)), CTuple{4}(randn(4)...)); check_inferred = false)
+        end
+    end
+
+    @testset "tuple output (backing type of Composite =/= natural differential)" begin
+        tuple_out(x) = return (x, 1.0) # i.e. (x, 1.0) and not (x, x)
+        function ChainRulesCore.frule((_, dx), ::typeof(tuple_out), x)
+            Ω = tuple_out(x)
+            ∂Ω = Composite{typeof(Ω)}(dx, Zero())
+            return Ω, ∂Ω
+        end
+        frule_test(tuple_out, (2.0, 1))
+    end
+
+    @testset "ignoring arguments" begin
+        fsymtest(x, s::Symbol) = x
+        ChainRulesCore.frule((_, Δx, _), ::typeof(fsymtest), x, s) = (x, Δx)
+        function ChainRulesCore.rrule(::typeof(fsymtest), x, s)
+            function fsymtest_pullback(Δx)
+                return NO_FIELDS, Δx, DoesNotExist()
+            end
+            return x, fsymtest_pullback
+        end
+
+        @testset "frule_test" begin
+            frule_test(fsymtest, (randn(), randn()), (:x, nothing))
+        end
+
+        @testset "rrule_test" begin
+            rrule_test(fsymtest, randn(), (randn(), randn()), (:x, nothing))
+        end
+    end
+
+    @testset "unary with kwargs: futestkws(x; err)" begin
+        function ChainRulesCore.frule((_, ẋ), ::typeof(futestkws), x; err = true)
+            return futestkws(x; err = err), ẋ
+        end
+        function ChainRulesCore.rrule(::typeof(futestkws), x; err = true)
+            function futestkws_pullback(Δx)
+                return (NO_FIELDS, Δx)
+            end
+            return futestkws(x; err = err), futestkws_pullback
+        end
+
+        # we defined these functions at top of file to throw errors unless we pass `err=false`
+        @test_throws ErrorException futestkws(randn())
+        @test_throws ErrorException test_scalar(futestkws, randn())
+        @test_throws ErrorException frule((nothing, randn()), futestkws, randn())
+        @test_throws ErrorException rrule(futestkws, randn())
+
+        @test_throws ErrorException futestkws(randn(4))
+        @test_throws ErrorException frule((nothing, randn(4)), futestkws, randn(4))
+        @test_throws ErrorException rrule(futestkws, randn(4))
+
+        @testset "scalar_test" begin
+            test_scalar(futestkws, randn(); fkwargs=(; err = false))
+        end
+        @testset "frule_test" begin
+            frule_test(futestkws, (randn(), randn()); fkwargs=(; err = false))
+            frule_test(futestkws, (randn(4), randn(4)); fkwargs=(; err = false))
+        end
+        @testset "rrule_test" begin
+            rrule_test(futestkws, randn(), (randn(), randn()); fkwargs=(; err = false))
+            rrule_test(futestkws, randn(4), (randn(4), randn(4)); fkwargs=(; err = false))
+        end
+    end
+
+    @testset "binary with kwargs: fbtestkws(x, y; err)" begin
+        function ChainRulesCore.frule((_, ẋ, _), ::typeof(fbtestkws), x, y; err = true)
+            return fbtestkws(x, y; err = err), ẋ
+        end
+        function ChainRulesCore.rrule(::typeof(fbtestkws), x, y; err = true)
+            function fbtestkws_pullback(Δx)
+                return (NO_FIELDS, Δx, Zero())
+            end
+            return fbtestkws(x, y; err = err), fbtestkws_pullback
+        end
+
+        # we defined these functions at top of file to throw errors unless we pass `err=false`
+        @test_throws ErrorException fbtestkws(randn(), randn())
+        @test_throws ErrorException frule((nothing, randn(), nothing), fbtestkws, randn(), randn())
+        @test_throws ErrorException rrule(fbtestkws, randn(), randn())
+
+        @test_throws ErrorException fbtestkws(randn(4), randn(4))
+        @test_throws ErrorException frule((nothing, randn(4), nothing), fbtestkws, randn(4), randn(4))
+        @test_throws ErrorException rrule(fbtestkws, randn(4), randn(4))
+
+        @testset "frule_test" begin
+            frule_test(fbtestkws, (randn(), randn()), (randn(), randn()); fkwargs=(; err = false))
+            frule_test(fbtestkws, (randn(4), randn(4)), (randn(4), randn(4)); fkwargs=(; err = false))
+        end
+        @testset "rrule_test" begin
+            rrule_test(fbtestkws, randn(), (randn(), randn()), (randn(), randn()); fkwargs=(; err = false))
+            rrule_test(fbtestkws, randn(4), (randn(4), randn(4)), (randn(4), randn(4)); fkwargs=(; err = false))
+        end
+    end
+end


### PR DESCRIPTION
Closes https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/67
Does option 2D witth `x ⊢ ẋ`
that is `\vdash` + <kbd>tab</kbd>
We can argue about symbols though.

- [x] input tangent
- [x] should make frule take an output tangent #66
- [x] should make frule and rrule's output tangent be auto-generated  
- [x] Should probably also do renaming from #96 to `test_frule` and `test_rrule`. Which should make deprecations easier
- [x] tests


#### before:

```julia
x = rand(4, 5)
x̄ = rand(4, 5)

ȳ = rand(2, 10)

rrule_test(reshape, ȳ, (x, x̄), ((2, 10), nothing))
rrule_test(reshape, ȳ, (x, x̄), (2, nothing), (10, nothing))
```

### After
No point declaring `x` in advance any-more.
Can just put the `rand` in-place

```julia
test_rrule(reshape, rand(4, 5), (2, 10) ⊢  nothing)
test_rrule(reshape, rand(4, 5), 2  ⊢  nothing, 10 ⊢  nothing)
```