### PR TITLE
wrap testers in top level testset

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,15 +58,12 @@ Keep this in mind when testing discontinuous rules for functions like [ReLU](htt
 ```jldoctest ex; output = false
 using ChainRulesTestUtils
 
-test_frule(two2three, 3.33, -7.77)
+test_frule(two2three, 3.33, -7.77);
+
 # output
-Test Summary:                    | Pass  Total
-Tuple{Float64,Float64,Float64}.1 |    1      1
-Test Summary:                    | Pass  Total
-Tuple{Float64,Float64,Float64}.2 |    1      1
-Test Summary:                    | Pass  Total
-Tuple{Float64,Float64,Float64}.3 |    1      1
-Test Passed
+Test Summary:                          | Pass  Total
+test_frule: two2three at (3.33, -7.77) |    5      5
+Test.DefaultTestSet("test_frule: two2three at (3.33, -7.77)", Any[Test.DefaultTestSet("Tuple{Float64,Float64,Float64}.1", Any[], 1, false), Test.DefaultTestSet("Tuple{Float64,Float64,Float64}.2", Any[], 1, false), Test.DefaultTestSet("Tuple{Float64,Float64,Float64}.3", Any[], 1, false)], 2, false)
 ```
 
 ### Testing the `rrule`
@@ -75,11 +72,12 @@ Test Passed
 The call will test the `rrule` for function `f` at the point `x`, and similarly to `frule` some rules should be tested at multiple points in the domain.
 
 ```jldoctest ex; output = false
-test_rrule(two2three, 3.33, -7.77)
+test_rrule(two2three, 3.33, -7.77);
+
 # output
-Test Summary:                      |
-Don't thunk only non_zero argument | No tests
-Test.DefaultTestSet("Don't thunk only non_zero argument", Any[], 0, false)
+Test Summary:                          | Pass  Total
+test_rrule: two2three at (3.33, -7.77) |    6      6
+Test.DefaultTestSet("test_rrule: two2three at (3.33, -7.77)", Any[Test.DefaultTestSet("Don't thunk only non_zero argument", Any[], 0, false)], 6, false)
 ```
 
 ## Scalar example
@@ -104,18 +102,15 @@ with the `frule` and `rrule` defined with the help of `@scalar_rule` macro
 `test_scalar` function is provided to test both the `frule` and the `rrule` with a single
 call.
 ```jldoctest ex; output = false
-test_scalar(relu, 0.5)
-test_scalar(relu, -0.5)
+test_scalar(relu, 0.5);
+test_scalar(relu, -0.5);
 
 # output
-Test Summary:                 | Pass  Total
-relu at 0.5, with tangent 1.0 |    3      3
-Test Summary:                   | Pass  Total
-relu at 0.5, with cotangent 1.0 |    4      4
-Test Summary:                  | Pass  Total
-relu at -0.5, with tangent 1.0 |    3      3
-Test Summary:                    | Pass  Total
-relu at -0.5, with cotangent 1.0 |    4      4
+Test Summary:            | Pass  Total
+test_scalar: relu at 0.5 |    7      7
+Test Summary:             | Pass  Total
+test_scalar: relu at -0.5 |    7      7
+Test.DefaultTestSet("test_scalar: relu at -0.5", Any[Test.DefaultTestSet("with tangent 1.0", Any[Test.DefaultTestSet("test_frule: relu at (ChainRulesTestUtils.PrimalAndTangent{Float64,Float64}(-0.5, 1.0),)", Any[], 3, false)], 0, false), Test.DefaultTestSet("with cotangent 1.0", Any[Test.DefaultTestSet("test_rrule: relu at (ChainRulesTestUtils.PrimalAndTangent{Float64,Float64}(-0.5, 1.0),)", Any[Test.DefaultTestSet("Don't thunk only non_zero argument", Any[], 0, false)], 4, false)], 0, false)], 0, false)
 ```
 
 ## Specifying Tangents

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -162,7 +162,10 @@ end
 
         # we defined these functions at top of file to throw errors unless we pass `err=false`
         @test_throws ErrorException futestkws(randn())
-        @test_throws ErrorException test_scalar(futestkws, randn())
+        @test errors(
+            ()->test_scalar(futestkws, randn()),
+            "futestkws_err",
+        )
         @test_throws ErrorException frule((nothing, randn()), futestkws, randn())
         @test_throws ErrorException rrule(futestkws, randn())
 

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -5,7 +5,8 @@
 """
     NonPassingTestset(desc, results) <: AbstractTestset
 
-A custom testset that doesn't let anything propagate up to the parent testset (or top-level fallback to throwning an error).
+A custom testset that doesn't let anything propagate up to the parent testset 
+(or to the top-level fallback testset, which throws an error on any non-passing result).
 Not passes, not failures, not even errors.
 
 This is useful for being able to observe the testsets results programatically.

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -3,7 +3,7 @@
 # MetaTesting.jl
 
 """
-    EncasedTestset(desc, results) <: AbstractTestset
+    EncasedTestSet(desc, results) <: AbstractTestset
 
 A custom testset that encases all test results within, not letting them out.
 It doesn't let anything propagate up to the parent testset
@@ -14,20 +14,20 @@ Not passes, not failures, not even errors.
 This is useful for being able to observe the testsets results programatically;
 without them triggering actual passes/failures/errors.
 """
-struct EncasedTestset <: Test.AbstractTestSet
+struct EncasedTestSet <: Test.AbstractTestSet
     description::String
     results::Vector{Any}
 end
-EncasedTestset(desc) = EncasedTestset(desc, [])
+EncasedTestSet(desc) = EncasedTestSet(desc, [])
 
-Test.record(ts::EncasedTestset, t) = (push!(ts.results, t); t)
+Test.record(ts::EncasedTestSet, t) = (push!(ts.results, t); t)
 
-function Test.finish(ts::EncasedTestset)
+function Test.finish(ts::EncasedTestSet)
     if Test.get_testset_depth() != 0
         # Attach this test set to the parent test set *if* it is also a NonPassingTestset
         # Otherwise don't as we don't want to push the errors and failures further up.
         parent_ts = Test.get_testset()
-        parent_ts isa EncasedTestset && Test.record(parent_ts, ts)
+        parent_ts isa EncasedTestSet && Test.record(parent_ts, ts)
         return ts
     end
     return ts
@@ -43,7 +43,7 @@ current testset, and will return a collection of all nonpassing test results.
 """
 function nonpassing_results(f)
     # Specify testset type to hijack system
-    ts = @testset EncasedTestset "nonpassing internal" begin
+    ts = @testset EncasedTestSet "nonpassing internal" begin
         f()
     end
     return _extract_nonpasses(ts)
@@ -52,7 +52,7 @@ end
 "extracts as flat collection of failures from a (potential nested) testset"
 _extract_nonpasses(x::Test.Result) = [x,]
 _extract_nonpasses(x::Test.Pass) = Test.Result[]
-_extract_nonpasses(ts::EncasedTestset) = _extract_nonpasses(ts.results)
+_extract_nonpasses(ts::EncasedTestSet) = _extract_nonpasses(ts.results)
 function _extract_nonpasses(xs::Vector)
     if isempty(xs)
         return Test.Result[]

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -17,7 +17,6 @@ end
 NonPassingTestset(desc) = NonPassingTestset(desc, [])
 
 # Records nothing, and throws an error immediately whenever a Fail or
-# Error occurs. Takes no action in the event of a Pass or Broken result
 Test.record(ts::NonPassingTestset, t) = (push!(ts.results, t); t)
 
 function Test.finish(ts::NonPassingTestset)

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -81,7 +81,7 @@ end
 """
     errors(f, msg_pattern="")
 
-`errors(f, msg_pattern)` returns true if at least 1 error is recorded into a testset,
+Returns true if at least 1 error is recorded into a testset
     with a failure matching the given pattern.
 
 `f` should be a function that takes no argument, and calls some code that uses `@testset`.

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -3,28 +3,31 @@
 # MetaTesting.jl
 
 """
-    NonPassingTestset(desc, results) <: AbstractTestset
+    EncasedTestset(desc, results) <: AbstractTestset
 
-A custom testset that doesn't let anything propagate up to the parent testset 
+A custom testset that encases all test results within, not letting them out.
+It doesn't let anything propagate up to the parent testset
 (or to the top-level fallback testset, which throws an error on any non-passing result).
 Not passes, not failures, not even errors.
 
-This is useful for being able to observe the testsets results programatically.
+
+This is useful for being able to observe the testsets results programatically;
+without them triggering actual passes/failures/errors.
 """
-struct NonPassingTestset <: Test.AbstractTestSet
+struct EncasedTestset <: Test.AbstractTestSet
     description::String
     results::Vector{Any}
 end
-NonPassingTestset(desc) = NonPassingTestset(desc, [])
+EncasedTestset(desc) = EncasedTestset(desc, [])
 
-Test.record(ts::NonPassingTestset, t) = (push!(ts.results, t); t)
+Test.record(ts::EncasedTestset, t) = (push!(ts.results, t); t)
 
-function Test.finish(ts::NonPassingTestset)
+function Test.finish(ts::EncasedTestset)
     if Test.get_testset_depth() != 0
         # Attach this test set to the parent test set *if* it is also a NonPassingTestset
         # Otherwise don't as we don't want to push the errors and failures further up.
         parent_ts = Test.get_testset()
-        parent_ts isa NonPassingTestset && Test.record(parent_ts, ts)
+        parent_ts isa EncasedTestset && Test.record(parent_ts, ts)
         return ts
     end
     return ts
@@ -40,7 +43,7 @@ current testset, and will return a collection of all nonpassing test results.
 """
 function nonpassing_results(f)
     # Specify testset type to hijack system
-    ts = @testset NonPassingTestset "nonpassing internal" begin
+    ts = @testset EncasedTestset "nonpassing internal" begin
         f()
     end
     return _extract_nonpasses(ts)
@@ -49,7 +52,7 @@ end
 "extracts as flat collection of failures from a (potential nested) testset"
 _extract_nonpasses(x::Test.Result) = [x,]
 _extract_nonpasses(x::Test.Pass) = Test.Result[]
-_extract_nonpasses(ts::NonPassingTestset) = _extract_nonpasses(ts.results)
+_extract_nonpasses(ts::EncasedTestset) = _extract_nonpasses(ts.results)
 function _extract_nonpasses(xs::Vector)
     if isempty(xs)
         return Test.Result[]
@@ -100,9 +103,6 @@ function errors(f, msg_pattern="")
     end
     return false  # no matching error occured
 end
-
-
-
 
 #Meta Meta tests
 @testset "meta_testing_tools.jl" begin

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -16,7 +16,6 @@ struct NonPassingTestset <: Test.AbstractTestSet
 end
 NonPassingTestset(desc) = NonPassingTestset(desc, [])
 
-# Records nothing, and throws an error immediately whenever a Fail or
 Test.record(ts::NonPassingTestset, t) = (push!(ts.results, t); t)
 
 function Test.finish(ts::NonPassingTestset)

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -82,7 +82,7 @@ end
     errors(f, msg_pattern="")
 
 Returns true if at least 1 error is recorded into a testset
-    with a failure matching the given pattern.
+with a failure matching the given pattern.
 
 `f` should be a function that takes no argument, and calls some code that uses `@testset`.
 `msg_pattern` is a regex or a string, that should be contained in the error message.

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -75,7 +75,6 @@ end
 """
     errors(f, msg_pattern="")
 
-
 `errors(f, msg_pattern)` returns true if at least 1 error is recorded into a testset,
     with a failure matching the given pattern.
 

--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -2,6 +2,14 @@
 # if they were less nasty in implementation we might consider moving them to a package
 # MetaTesting.jl
 
+"""
+    NonPassingTestset(desc, results) <: AbstractTestset
+
+A custom testset that doesn't let anything propagate up to the parent testset (or top-level fallback to throwning an error).
+Not passes, not failures, not even errors.
+
+This is useful for being able to observe the testsets results programatically.
+"""
 struct NonPassingTestset <: Test.AbstractTestSet
     description::String
     results::Vector{Any}

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -1,7 +1,7 @@
 # For some reason if these aren't defined here, then they are interpreted as closures
-futestkws(x; err = true) = err ? error() : x
+futestkws(x; err = true) = err ? error("futestkws_err") : x
 
-fbtestkws(x, y; err = true) = err ? error() : x
+fbtestkws(x, y; err = true) = err ? error("fbtestkws_err") : x
 
 sinconj(x) = sin(x)
 
@@ -126,11 +126,16 @@ end
             end
 
             test_frule(f_noninferrable_frule, 2.0; check_inferred = false)
-            @test_throws ErrorException test_frule(f_noninferrable_frule, 2.0)
+            @test errors(
+                ()->test_frule(f_noninferrable_frule, 2.0),
+                "does not match inferred return type"
+            )
+
             test_scalar(f_noninferrable_frule, 2.0; check_inferred = false)
-            # `fails` plucks out `ErrorException` raised by `@inferred` from nested `TestSet`
-            # `mute` silences the printed error
-            @test_throws ErrorException mute(() -> fails(() -> test_scalar(f_noninferrable_frule, 2.0)))
+            @test errors(
+                ()->test_scalar(f_noninferrable_frule, 2.0),
+                "does not match inferred return type"
+            )
         end
 
         @testset "check not inferred in rrule" begin
@@ -145,11 +150,16 @@ end
             end
 
             test_rrule(f_noninferrable_rrule, 2.0; check_inferred = false)
-            @test_throws ErrorException test_rrule(f_noninferrable_rrule, 2.0)
+            @test errors(
+                ()->test_rrule(f_noninferrable_rrule, 2.0),
+                "does not match inferred return type"
+            )
+
             test_scalar(f_noninferrable_rrule, 2.0; check_inferred = false)
-            # `fails` plucks out `ErrorException` raised by `@inferred` from nested `TestSet`
-            # `mute` silences the printed error
-            @test_throws ErrorException mute(() -> fails(() -> test_scalar(f_noninferrable_rrule, 2.0)))
+            @test errors(
+                ()->test_scalar(f_noninferrable_rrule, 2.0),
+                "does not match inferred return type"
+            )
         end
 
         @testset "check not inferred in pullback" begin
@@ -158,7 +168,10 @@ end
                 return x, f_noninferrable_pullback_pullback
             end
             test_rrule(f_noninferrable_pullback, 2.0; check_inferred = false)
-            @test_throws ErrorException test_rrule(f_noninferrable_pullback, 2.0)
+            @test errors(
+                ()->test_rrule(f_noninferrable_pullback, 2.0),
+                "does not match inferred return type"
+            )
         end
 
         @testset "check not inferred in thunk" begin
@@ -170,7 +183,10 @@ end
                 return x + y, f_noninferrable_thunk_pullback
             end
             test_rrule(f_noninferrable_thunk, 2.0, 3.0; check_inferred = false)
-            @test_throws ErrorException test_rrule(f_noninferrable_thunk, 2.0, 3.0)
+            @test errors(
+                ()->test_rrule(f_noninferrable_thunk, 2.0, 3.0),
+                "does not match inferred return type"
+            )
         end
 
         @testset "check non-inferrable primal still passes if pullback inferrable" begin
@@ -303,7 +319,7 @@ end
 
         # we defined these functions at top of file to throw errors unless we pass `err=false`
         @test_throws ErrorException futestkws(randn())
-        @test_throws ErrorException test_scalar(futestkws, randn())
+        @test errors(()->test_scalar(futestkws, randn()), "futestkws_err")
         @test_throws ErrorException frule((nothing, randn()), futestkws, randn())
         @test_throws ErrorException rrule(futestkws, randn())
 


### PR DESCRIPTION
example output
```julia
julia> test_rrule(two2three, 3.33, -7.77)
Test Summary:                          | Pass  Total
test_rrule: two2three at (3.33, -7.77) |    6      6
Test.DefaultTestSet("test_rrule: two2three at (3.33, -7.77)", Any[Test.DefaultTestSet("Don't thunk only non_zero argument", Any[], 0, false)], 6, false)
````

Closes #121 and #108 


I recomment turning on "hide whitespace changes" when reviewing,
since this indented a ton of code without changing it

---
<img width="647" alt="image" src="https://user-images.githubusercontent.com/5127634/110324555-0cf1c200-800e-11eb-94d9-cc25644c6fb2.png">
