### PR TITLE
no more `⊢` for types for which rand_tangent gives DoesNotExist

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -117,7 +117,7 @@ Test.DefaultTestSet("test_scalar: relu at -0.5", Any[Test.DefaultTestSet("with t
 [`test_frule`](@ref) and [`test_rrule`](@ref) allow you to specify the tangents used for testing.
 This is done by passing in `x ⊢ Δx`, where `x` is the primal and `Δx` is the tangent, in the place of the primal inputs.
 If this is not done the tangent will be automatically generated via [`ChainRulesTestUtils.rand_tangent`](@ref).
-A special case of this is that if you specify it as `x ⊢ nothing` then finite differencing will not be used on that input.
+A special case of this is that if you specify it as `x ⊢ DoesNotExist()` then finite differencing will not be used on that input.
 Similarly, by setting the `output_tangent` keyword argument, you can specify the tangent for the primal output.
 
 This can be useful when the default provided [`ChainRulesTestUtils.rand_tangent`](@ref) doesn't produce the desired tangent for your type.

--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -29,6 +29,10 @@ check_equal(::Zero, x; kwargs...) = check_equal(zero(x), x; kwargs...)
 check_equal(x, ::Zero; kwargs...) = check_equal(x, zero(x); kwargs...)
 check_equal(x::Zero, y::Zero; kwargs...) = @test true
 
+# remove once https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/113
+check_equal(x::DoesNotExist, y::Nothing; kwargs...) = @test true
+check_equal(x::Nothing, y::DoesNotExist; kwargs...) = @test true
+
 """
     _can_pass_early(actual, expected; kwargs...)
 Used to check if `actual` is basically equal to `expected`, so we don't need to check deeper;

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -182,7 +182,7 @@ function test_rrule(
         @test ∂self === NO_FIELDS  # No internal fields
 
         # Correctness testing via finite differencing.
-        x̄s_is_dne = accumulated_x̄ .== nothing
+        x̄s_is_dne = isa.(accumulated_x̄, Union{Nothing, DoesNotExist})
         x̄s_fd = _make_j′vp_call(fdm, (xs...) -> f(xs...; fkwargs...), ȳ, xs, x̄s_is_dne)
         for (accumulated_x̄, x̄_ad, x̄_fd) in zip(accumulated_x̄, x̄s_ad, x̄s_fd)
             if accumulated_x̄ === nothing  # then we marked this argument as not differentiable

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -116,6 +116,14 @@ function test_frule(
 
         # TODO: remove Nothing when https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/113
         ẋs_is_ignored = isa.(ẋs, Union{Nothing, DoesNotExist})
+        if any(ẋs .== nothing)
+            Base.depwarn(
+                "test_frule(f, k ⊢ nothing) is deprecated, use " *
+                "test_frule(f, k ⊢ DoesNotExist()) instead for non-differentiable ks",
+                :test_frule
+            )
+        end
+
         # Correctness testing via finite differencing.
         dΩ_fd = _make_jvp_call(fdm, (xs...) -> f(deepcopy(xs)...; deepcopy(fkwargs)...), Ω, xs, ẋs, ẋs_is_ignored)
         check_equal(dΩ_ad, dΩ_fd; isapprox_kwargs...)
@@ -185,6 +193,14 @@ function test_rrule(
         # Correctness testing via finite differencing.
         # TODO: remove Nothing when https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/113
         x̄s_is_dne = isa.(accumulated_x̄, Union{Nothing, DoesNotExist})
+        if any(accumulated_x̄ .== nothing)
+            Base.depwarn(
+                "test_rrule(f, k ⊢ nothing) is deprecated, use " *
+                "test_rrule(f, k ⊢ DoesNotExist()) instead for non-differentiable ks",
+                :test_rrule
+            )
+        end
+
         x̄s_fd = _make_j′vp_call(fdm, (xs...) -> f(xs...; fkwargs...), ȳ, xs, x̄s_is_dne)
         for (accumulated_x̄, x̄_ad, x̄_fd) in zip(accumulated_x̄, x̄s_ad, x̄s_fd)
             if accumulated_x̄ === nothing  # then we marked this argument as not differentiable

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -182,6 +182,7 @@ function test_rrule(
         @test ∂self === NO_FIELDS  # No internal fields
 
         # Correctness testing via finite differencing.
+        # TODO: remove Nothing when https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/113
         x̄s_is_dne = isa.(accumulated_x̄, Union{Nothing, DoesNotExist})
         x̄s_fd = _make_j′vp_call(fdm, (xs...) -> f(xs...; fkwargs...), ȳ, xs, x̄s_is_dne)
         for (accumulated_x̄, x̄_ad, x̄_fd) in zip(accumulated_x̄, x̄s_ad, x̄s_fd)

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -75,7 +75,7 @@ end
 - `inputs` either the primal inputs `x`, or primals and their tangents: `x ⊢ ẋ`
    - `x`: input at which to evaluate `f` (should generally be set to an arbitary point in the domain).
    - `ẋ`: differential w.r.t. `x`, will be generated automatically if not provided
-     Non-differentiable arguments, such as indices, should have `ẋ` set as `nothing`.
+   Non-differentiable arguments, such as indices, should have `ẋ` set as `DoesNotExist()`.
 
 # Keyword Arguments
    - `output_tangent` tangent to test accumulation of derivatives against
@@ -143,7 +143,7 @@ end
 - `inputs` either the primal inputs `x`, or primals and their tangents: `x ⊢ ẋ`
     - `x`: input at which to evaluate `f` (should generally be set to an arbitary point in the domain).
     - `x̄`: currently accumulated cotangent, will be generated automatically if not provided
-      Non-differentiable arguments, such as indices, should have `x̄` set as `nothing`.
+    Non-differentiable arguments, such as indices, should have `x̄` set as `DoesNotExist()`.
 
 # Keyword Arguments
  - `output_tangent` the seed to propagate backward for testing (techncally a cotangent).
@@ -203,7 +203,7 @@ function test_rrule(
 
         x̄s_fd = _make_j′vp_call(fdm, (xs...) -> f(xs...; fkwargs...), ȳ, xs, x̄s_is_dne)
         for (accumulated_x̄, x̄_ad, x̄_fd) in zip(accumulated_x̄, x̄s_ad, x̄s_fd)
-            if accumulated_x̄ === nothing  # then we marked this argument as not differentiable
+            if accumulated_x̄ isa Union{Nothing, DoesNotExist}  # then we marked this argument as not differentiable # TODO remove once #113
                 @assert x̄_fd === nothing  # this is how `_make_j′vp_call` works
                 @test x̄_ad isa DoesNotExist  # we said it wasn't differentiable.
             else

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -114,7 +114,8 @@ function test_frule(
         Ω = f(deepcopy(xs)...; deepcopy(fkwargs)...)
         check_equal(Ω_ad, Ω; isapprox_kwargs...)
 
-        ẋs_is_ignored = ẋs .== nothing
+        # TODO: remove Nothing when https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/113
+        ẋs_is_ignored = isa.(ẋs, Union{Nothing, DoesNotExist})
         # Correctness testing via finite differencing.
         dΩ_fd = _make_jvp_call(fdm, (xs...) -> f(deepcopy(xs)...; deepcopy(fkwargs)...), Ω, xs, ẋs, ẋs_is_ignored)
         check_equal(dΩ_ad, dΩ_fd; isapprox_kwargs...)


### PR DESCRIPTION
Closes #128 , closes #113