### PR TITLE
fix tests for 1.6

### DIFF
--- a/test/meta_testing_tools.jl
+++ b/test/meta_testing_tools.jl
@@ -106,6 +106,7 @@ end
 
 #Meta Meta tests
 @testset "meta_testing_tools.jl" begin
+    maybe_expr2string = VERSION < v"1.6" ? identity : Meta.parse
     @testset "Checking for non-passes" begin
         @testset "No Tests" begin
             fails = nonpassing_results(()->nothing)
@@ -121,7 +122,7 @@ end
         @testset "Single Test" begin
             fails = nonpassing_results(()->@test false)
             @test length(fails) === 1
-            @test fails[1].orig_expr == false
+            @test maybe_expr2string(fails[1].orig_expr) == false
         end
 
         @testset "Single Testset" begin
@@ -132,8 +133,8 @@ end
                 end
             end
             @test length(fails) === 2
-            @test fails[1].orig_expr == :(false==true)
-            @test fails[2].orig_expr == :(true==false)
+            @test maybe_expr2string(fails[1].orig_expr) == :(false==true)
+            @test maybe_expr2string(fails[2].orig_expr) == :(true==false)
         end
 
 


### PR DESCRIPTION
Fixes the tests failing on 1.6.

If i understand things correctly the `Test.Fail` object has changed its representation of its `orig_expr` field from `Expr` to `String`.

This fix is pretty terrible, any other ideas?