### PR TITLE
Add support for `BigFloat` to `rand_tangent`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/generate_tangent.jl
+++ b/src/generate_tangent.jl
@@ -54,6 +54,9 @@ rand_tangent(rng::AbstractRNG, x::Integer) = DoesNotExist()
 
 rand_tangent(rng::AbstractRNG, x::T) where {T<:Number} = randn(rng, T)
 
+# ref: https://github.com/JuliaLang/julia/issues/17629
+rand_tangent(rng::AbstractRNG, ::BigFloat) = big(randn(rng))
+
 rand_tangent(rng::AbstractRNG, x::StridedArray) = rand_tangent.(Ref(rng), x)
 
 function rand_tangent(rng::AbstractRNG, x::T) where {T<:Tuple}

--- a/test/generate_tangent.jl
+++ b/test/generate_tangent.jl
@@ -17,6 +17,7 @@ end
         (true, DoesNotExist),
         (4, DoesNotExist),
         (5.0, Float64),
+        (big(5.0), BigFloat),
         (5.0 + 0.4im, Complex{Float64}),
         (randn(Float32, 3), Vector{Float32}),
         (randn(Complex{Float64}, 2), Vector{Complex{Float64}}),


### PR DESCRIPTION
This PR adds support for `BigFloat` to `rand_tangent`. This came up in https://github.com/JuliaStats/StatsFuns.jl/pull/106.