### PR TITLE
Better error message when user accidentally passes `Zero()` instead of `DoesNotExist()` in the pullback

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.6.6"
+version = "0.6.7"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -207,7 +207,7 @@ function test_rrule(
                 @assert x̄_fd === nothing  # this is how `_make_j′vp_call` works
                 x̄_ad isa Zero && error(
                     "The pullback in the rrule for $f function should use DoesNotExist()" *
-                    " rather than Zero() for non-differentiable arguments."
+                    " rather than Zero() for non-perturbable arguments."
                 )
                 @test x̄_ad isa DoesNotExist  # we said it wasn't differentiable.
             else

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -205,6 +205,10 @@ function test_rrule(
         for (accumulated_x̄, x̄_ad, x̄_fd) in zip(accumulated_x̄, x̄s_ad, x̄s_fd)
             if accumulated_x̄ isa Union{Nothing, DoesNotExist}  # then we marked this argument as not differentiable # TODO remove once #113
                 @assert x̄_fd === nothing  # this is how `_make_j′vp_call` works
+                x̄_ad isa Zero && error(
+                    "The pullback in the rrule for $f function should use DoesNotExist()" *
+                    " rather than Zero() for non-differentiable arguments."
+                )
                 @test x̄_ad isa DoesNotExist  # we said it wasn't differentiable.
             else
                 x̄_ad isa AbstractThunk && check_inferred && _test_inferred(unthunk, x̄_ad)

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -507,4 +507,17 @@ end
         end
         test_rrule(rev_trouble, (3, 3.0) ⊢ Composite{Tuple{Int, Float64}}(Zero(), 1.0))
     end
+
+    @testset "error message about incorrectly using Zero()" begin
+        foo(a, i) = a[i]
+        function ChainRulesCore.rrule(::typeof(foo), a, i)
+            function foo_pullback(Δy)
+                da = zeros(size(a))
+                da[i] = Δy
+                return NO_FIELDS, da, Zero()
+            end
+            return foo(a, i), foo_pullback
+        end
+        @test errors(() -> test_rrule(foo, [1.0, 2.0, 3.0], 2), "should use DoesNotExist()")
+    end
 end


### PR DESCRIPTION
Closes #112 

I don't think we need a test for this?