### PR TITLE
Enable testing of rules with `@not_implemented`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.6.6"
+version = "0.6.7"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ChainRulesCore = "0.9.38"
+ChainRulesCore = "0.9.39"
 Compat = "3"
 FiniteDifferences = "0.12"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.6.7"
+version = "0.6.8"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ChainRulesCore = "0.9.13"
+ChainRulesCore = "0.9.38"
 Compat = "3"
 FiniteDifferences = "0.12"
 julia = "1"

--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -33,10 +33,10 @@ check_equal(x::Zero, y::Zero; kwargs...) = @test true
 check_equal(x::DoesNotExist, y::Nothing; kwargs...) = @test true
 check_equal(x::Nothing, y::DoesNotExist; kwargs...) = @test true
 
-check_equal(::ChainRulesCore.NotImplemented, x; kwargs...) = @test true
-check_equal(x, ::ChainRulesCore.NotImplemented; kwargs...) = @test true
+check_equal(::ChainRulesCore.NotImplemented, x; kwargs...) = @test_broken false
+check_equal(x, ::ChainRulesCore.NotImplemented; kwargs...) = @test_broken false
 function check_equal(::ChainRulesCore.NotImplemented, ::ChainRulesCore.NotImplemented; kwargs...)
-    return @test true
+    return @test_broken false
 end
 
 """
@@ -145,10 +145,10 @@ function _check_add!!_behaviour(acc, val; kwargs...)
 end
 
 # `+` is not defined for `NotImplemented`
-_check_add!!_behaviour(acc, ::ChainRulesCore.NotImplemented; kwargs...) = @test true
-_check_add!!_behaviour(::ChainRulesCore.NotImplemented, val; kwargs...) = @test true
+_check_add!!_behaviour(acc, ::ChainRulesCore.NotImplemented; kwargs...) = @test_broken false
+_check_add!!_behaviour(::ChainRulesCore.NotImplemented, val; kwargs...) = @test_broken false
 function _check_add!!_behaviour(
     ::ChainRulesCore.NotImplemented, ::ChainRulesCore.NotImplemented; kwargs...
 )
-    return @test true
+    return @test_broken false
 end

--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -35,10 +35,14 @@ check_equal(x::Nothing, y::DoesNotExist; kwargs...) = @test true
 
 # Checking equality with `NotImplemented` reports `@test_broken` since the derivative has intentionally
 # not yet been implemented
-check_equal(::ChainRulesCore.NotImplemented, x; kwargs...) = @test_broken false
-check_equal(x, ::ChainRulesCore.NotImplemented; kwargs...) = @test_broken false
-function check_equal(::ChainRulesCore.NotImplemented, ::ChainRulesCore.NotImplemented; kwargs...)
-    return @test_broken false
+# `@test_broken x == y` yields more descriptive messages than `@test_broken false`
+check_equal(x::ChainRulesCore.NotImplemented, y; kwargs...) = @test_broken x == y
+check_equal(x, y::ChainRulesCore.NotImplemented; kwargs...) = @test_broken x == y
+# In this case we check for equality (messages etc. have to be equal)
+function check_equal(
+    x::ChainRulesCore.NotImplemented, y::ChainRulesCore.NotImplemented; kwargs...
+)
+    return @test x == y
 end
 
 """
@@ -148,10 +152,17 @@ end
 
 # Checking equality with `NotImplemented` reports `@test_broken` since the derivative has intentionally
 # not yet been implemented
-_check_add!!_behaviour(acc, ::ChainRulesCore.NotImplemented; kwargs...) = @test_broken false
-_check_add!!_behaviour(::ChainRulesCore.NotImplemented, val; kwargs...) = @test_broken false
+# `@test_broken x == y` yields more descriptive messages than `@test_broken false`
+function _check_add!!_behaviour(acc_mutated, acc::ChainRulesCore.NotImplemented; kwargs...)
+    return @test_broken acc_mutated == acc
+end
+function _check_add!!_behaviour(acc_mutated::ChainRulesCore.NotImplemented, acc; kwargs...)
+    return @test_broken acc_mutated == acc
+end
+# In this case we check for equality (messages etc. have to be equal)
 function _check_add!!_behaviour(
-    ::ChainRulesCore.NotImplemented, ::ChainRulesCore.NotImplemented; kwargs...
+    acc_mutated::ChainRulesCore.NotImplemented, acc::ChainRulesCore.NotImplemented;
+    kwargs...,
 )
-    return @test_broken false
+    return @test acc_mutated == acc
 end

--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -33,6 +33,8 @@ check_equal(x::Zero, y::Zero; kwargs...) = @test true
 check_equal(x::DoesNotExist, y::Nothing; kwargs...) = @test true
 check_equal(x::Nothing, y::DoesNotExist; kwargs...) = @test true
 
+# Checking equality with `NotImplemented` reports `@test_broken` since the derivative has intentionalyl
+# not yet been implemented
 check_equal(::ChainRulesCore.NotImplemented, x; kwargs...) = @test_broken false
 check_equal(x, ::ChainRulesCore.NotImplemented; kwargs...) = @test_broken false
 function check_equal(::ChainRulesCore.NotImplemented, ::ChainRulesCore.NotImplemented; kwargs...)

--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -33,7 +33,7 @@ check_equal(x::Zero, y::Zero; kwargs...) = @test true
 check_equal(x::DoesNotExist, y::Nothing; kwargs...) = @test true
 check_equal(x::Nothing, y::DoesNotExist; kwargs...) = @test true
 
-# Checking equality with `NotImplemented` reports `@test_broken` since the derivative has intentionalyl
+# Checking equality with `NotImplemented` reports `@test_broken` since the derivative has intentionally
 # not yet been implemented
 check_equal(::ChainRulesCore.NotImplemented, x; kwargs...) = @test_broken false
 check_equal(x, ::ChainRulesCore.NotImplemented; kwargs...) = @test_broken false

--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -146,7 +146,8 @@ function _check_add!!_behaviour(acc, val; kwargs...)
     check_equal(add!!(acc_mutated, val), acc + val; kwargs...)
 end
 
-# `+` is not defined for `NotImplemented`
+# Checking equality with `NotImplemented` reports `@test_broken` since the derivative has intentionally
+# not yet been implemented
 _check_add!!_behaviour(acc, ::ChainRulesCore.NotImplemented; kwargs...) = @test_broken false
 _check_add!!_behaviour(::ChainRulesCore.NotImplemented, val; kwargs...) = @test_broken false
 function _check_add!!_behaviour(

--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -33,6 +33,12 @@ check_equal(x::Zero, y::Zero; kwargs...) = @test true
 check_equal(x::DoesNotExist, y::Nothing; kwargs...) = @test true
 check_equal(x::Nothing, y::DoesNotExist; kwargs...) = @test true
 
+check_equal(::ChainRulesCore.NotImplemented, x; kwargs...) = @test true
+check_equal(x, ::ChainRulesCore.NotImplemented; kwargs...) = @test true
+function check_equal(::ChainRulesCore.NotImplemented, ::ChainRulesCore.NotImplemented; kwargs...)
+    return @test true
+end
+
 """
     _can_pass_early(actual, expected; kwargs...)
 Used to check if `actual` is basically equal to `expected`, so we don't need to check deeper;
@@ -136,4 +142,13 @@ function _check_add!!_behaviour(acc, val; kwargs...)
     # That is what people should rely on. The mutation is just to save allocations.
     acc_mutated = deepcopy(acc)  # prevent this test changing others
     check_equal(add!!(acc_mutated, val), acc + val; kwargs...)
+end
+
+# `+` is not defined for `NotImplemented`
+_check_add!!_behaviour(acc, ::ChainRulesCore.NotImplemented; kwargs...) = @test true
+_check_add!!_behaviour(::ChainRulesCore.NotImplemented, val; kwargs...) = @test true
+function _check_add!!_behaviour(
+    ::ChainRulesCore.NotImplemented, ::ChainRulesCore.NotImplemented; kwargs...
+)
+    return @test true
 end

--- a/test/check_result.jl
+++ b/test/check_result.jl
@@ -48,7 +48,7 @@ end
 
             check_equal(@not_implemented(""), rand(3))
             check_equal(rand(3), @not_implemented(""))
-            check_equal(@not_implemented("a"), @not_implemented("b"))
+            check_equal(@not_implemented("a"), @not_implemented("a"))
 
             check_equal(
                 Composite{Tuple{Float64, Float64}}(1.0, 2.0),
@@ -96,6 +96,8 @@ end
             @test fails(()->check_equal([[1.0], [2.0]], [[1.1], [2.0]]))
 
             @test fails(()->check_equal(@thunk(10*[[1.0], [2.0]]), [[1.0], [2.0]]))
+
+            @test fails(()->check_equal(@not_implemented("a"), @not_implemented("b")))
         end
         @testset "type negative" begin
             @test fails() do  # these have different primals so should not be equal

--- a/test/check_result.jl
+++ b/test/check_result.jl
@@ -33,7 +33,7 @@ end
 
     @testset "check_equal" begin
 
-        @testset "possive cases" begin
+        @testset "positive cases" begin
             check_equal(1.0, 1.0)
             check_equal(1.0 + im, 1.0 + im)
             check_equal(1.0, 1.0+1e-10)  # isapprox _behaviour
@@ -45,6 +45,10 @@ end
             check_equal([[1.0], [2.0]], [[1.0], [2.0]])
 
             check_equal(@thunk(10*0.1*[[1.0], [2.0]]), [[1.0], [2.0]])
+
+            check_equal(@not_implemented(""), rand(3))
+            check_equal(rand(3), @not_implemented(""))
+            check_equal(@not_implemented("a"), @not_implemented("b"))
 
             check_equal(
                 Composite{Tuple{Float64, Float64}}(1.0, 2.0),

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -14,7 +14,6 @@ f_noninferrable_pullback(x) = x
 f_noninferrable_thunk(x, y) = x + y
 f_inferrable_pullback_only(x) = x > 0 ? Float64(x) : Float32(x)
 
-
 function finplace!(x; y = [1])
     y[1] = 2
     x .*= y[1]
@@ -506,5 +505,12 @@ end
             return y, rev_trouble_pullback
         end
         test_rrule(rev_trouble, (3, 3.0) ⊢ Composite{Tuple{Int, Float64}}(Zero(), 1.0))
+    end
+
+    @testset "NotImplemented" begin
+        f_notimplemented(x, y) = (x + y, x - y)
+        @scalar_rule f_notimplemented(x, y) (@not_implemented(""), 1) (1, -1)
+        test_frule(f_notimplemented, randn(), randn())
+        test_rrule(f_notimplemented, randn(), randn())
     end
 end


### PR DESCRIPTION
Currently tests fail since `check_add!!` errors for `Composite`s with a field of type `NotImplemented`: the implementation of `+` for `Composite` in ChainRulesCore uses `elementwise_add` which is implemented with `+` but `+` is not defined for `NotImplemented`.

My suggestion would be to allow operations with `Composite`s with fields of type `NotImplemented` similar to how `muladd` is enabled for `NotImplemented`, i.e., `NotImplemented` wins always, _but_ to not allow general calculations with `+`. This could be achieved by defining
```julia
_add(x, y) = x + y
_add(x::NotImplemented, y) = x
_add(::NotImplemented, y::NotImplemented) = y
_add(x::NotImplemented, ::NotImplemented) = x
```
and using `_add` instead of `+` in `elementwise_add`. I already confirmed that this would fix the test errors.