### PR TITLE
remove deprecated Symbol ⊢ nothing from tests

### DIFF
--- a/test/testers.jl
+++ b/test/testers.jl
@@ -298,11 +298,11 @@ end
         end
 
         @testset "test_frule" begin
-            test_frule(fsymtest, 2.5, :x ⊢ nothing)
+            test_frule(fsymtest, 2.5, :x)
         end
 
         @testset "test_rrule" begin
-            test_rrule(fsymtest, 2.5, :x ⊢ nothing)
+            test_rrule(fsymtest, 2.5, :x)
         end
     end
 


### PR DESCRIPTION
Following up on https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/129