### PR TITLE
Automatically ignore `Composite`s with all `DoesNotExist()` for finite differencing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.6.8"
+version = "0.6.9"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -164,7 +164,6 @@ function test_rrule(
     # To simplify some of the calls we make later lets group the kwargs for reuse
     isapprox_kwargs = (; rtol=rtol, atol=atol, kwargs...)
 
-    println("HI")
     @testset "test_rrule: $f at $inputs" begin
         _ensure_not_running_on_functor(f, "test_rrule")
 

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -251,9 +251,7 @@ Returns true for tangents we want to ignore in finite differencing, and false ot
 _ignore(::Any) = false
 _ignore(::DoesNotExist) = true
 _ignore(::Nothing) = true # TODO: remove Nothing when https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/113
-function _ignore(c::Composite)
-    return all([d === DoesNotExist() for d in c])
-end
+_ignore(c::Composite) = all([d === DoesNotExist() for d in c])
 
 """
     _test_inferred(f, args...; kwargs...)

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -246,7 +246,7 @@ end
 """
     _ignore(x) -> Bool
 
-Decides whether to ignore certain kinds of arguments for finite differencing.
+Returns true for tangents we want to ignore in finite differencing, and false otherwise.
 """
 _ignore(::Any) = false
 _ignore(::DoesNotExist) = true


### PR DESCRIPTION
Do we want this?

Closes https://github.com/JuliaDiff/FiniteDifferences.jl/issues/149