### PR TITLE
Change `check_thunking_is_appropriate` to a warning

### DIFF
--- a/src/testers.jl
+++ b/src/testers.jl
@@ -219,17 +219,15 @@ function test_rrule(
             end
         end
 
-        check_thunking_is_appropriate(x̄s_ad)
+        check_thunking_is_appropriate(f, x̄s_ad)
     end  # top-level testset
 end
 
-function check_thunking_is_appropriate(x̄s)
-    @testset "Don't thunk only non_zero argument" begin
-        num_zeros = count(x->x isa AbstractZero, x̄s)
-        num_thunks = count(x->x isa Thunk, x̄s)
-        if num_zeros + num_thunks == length(x̄s)
-            @test num_thunks !== 1
-        end
+function check_thunking_is_appropriate(f, x̄s)
+    num_zeros = count(x->x isa AbstractZero, x̄s)
+    num_thunks = count(x->x isa Thunk, x̄s)
+    if num_thunks == 1 && num_zeros + num_thunks == length(x̄s)
+        @warn "function has a thunk for its only non-zero argument, this works but is considered poor style" f
     end
 end
 


### PR DESCRIPTION
While thunking the sole nonzero argument may be unnecessary, it hardly seems the kind of grave sin for which waiting another hour for CI to tell you what else is actually wrong is the appropriate punishment. So this makes it a friendly warning instead.

For precedent, note that `Base.literal_pow(^, x, Val(1))` could safely be made an error since clearly you are wasting pixels if you write `x^1` and should ideally go and clean up. But it's nice that it isn't.