### PR TITLE
RFC: Check only non-zero argument not an InpaceableThunk?

### DIFF
--- a/src/testers.jl
+++ b/src/testers.jl
@@ -134,7 +134,6 @@ function test_frule(
 end
 
 
-
 """
     test_rrule(f, inputs...; kwargs...)
 
@@ -225,8 +224,8 @@ end
 
 function check_thunking_is_appropriate(x̄s)
     @testset "Don't thunk only non_zero argument" begin
-        num_zeros = count(x->x isa AbstractZero, x̄s)
-        num_thunks = count(x->x isa Thunk, x̄s)
+        num_zeros = count(x -> x isa AbstractZero, x̄s)
+        num_thunks = count(x -> x isa AbstractThunk, x̄s)
         if num_zeros + num_thunks == length(x̄s)
             @test num_thunks !== 1
         end


### PR DESCRIPTION
Raised by @mcabbott at https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/144#issuecomment-832361804

> My original case was one InplaceableThunk, which was causing type instabilities, so I commented out the in-place part, leaving the @thunk. So you have to know that it's only one kind of thunk not the other which isn't allowed to be alone.

Is this intended? If no, this PR fixes it. If it is intended for `Thunk` to be treated differently than `InpaceableThunk` we should probably have docs about that...