### PR TITLE
tag new release to make available on Zenodo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.6.10"
+version = "0.6.11"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
I am trying to register ChainRules and related repos at https://zenodo.org/. For a repo to show up though, a new release has to be tagged. Sorry for the noise!