### PR TITLE
Add deprecation warnings to isapprox

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,5 +1,4 @@
 # TODO remove these in version 0.7
-# We are silently deprecating them as there is no alternative we are providing
 
 function Base.isapprox(a, b::Union{AbstractZero,AbstractThunk}; kwargs...)
     Base.depwarn(

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -2,38 +2,80 @@
 # We are silently deprecating them as there is no alternative we are providing
 
 function Base.isapprox(a, b::Union{AbstractZero,AbstractThunk}; kwargs...)
+    Base.depwarn(
+        "isapprox is deprecated on AbstractTangents and will be removed. " *
+        "Restructure testing code to use `ChainRulesTestUtils.test_approx` instead.",
+        :isapprox,
+    )
     return isapprox(b, a; kwargs...)
 end
 function Base.isapprox(d_ad::AbstractThunk, d_fd; kwargs...)
+    Base.depwarn(
+        "isapprox is deprecated on AbstractTangents and will be removed. " *
+        "Restructure testing code to use `ChainRulesTestUtils.test_approx` instead.",
+        :isapprox,
+    )
     return isapprox(extern(d_ad), d_fd; kwargs...)
 end
 function Base.isapprox(d_ad::NoTangent, d_fd; kwargs...)
+    Base.depwarn(
+        "isapprox is deprecated on AbstractTangents and will be removed. " *
+        "Restructure testing code to use `ChainRulesTestUtils.test_approx` instead.",
+        :isapprox,
+    )
     return error("Tried to differentiate w.r.t. a `NoTangent`")
 end
 # Call `all` to handle the case where `ZeroTangent` is standing in for a non-scalar zero
 function Base.isapprox(d_ad::ZeroTangent, d_fd; kwargs...)
+    Base.depwarn(
+        "isapprox is deprecated on AbstractTangents and will be removed. " *
+        "Restructure testing code to use `ChainRulesTestUtils.test_approx` instead.",
+        :isapprox,
+    )
     return all(isapprox.(extern(d_ad), d_fd; kwargs...))
 end
 
 isapprox_vec(a, b; kwargs...) = isapprox(first(to_vec(a)), first(to_vec(b)); kwargs...)
 Base.isapprox(a, b::Tangent; kwargs...) = isapprox(b, a; kwargs...)
 function Base.isapprox(d_ad::Tangent{<:Tuple}, d_fd::Tuple; kwargs...)
+    Base.depwarn(
+        "isapprox is deprecated on AbstractTangents and will be removed. " *
+        "Restructure testing code to use `ChainRulesTestUtils.test_approx` instead.",
+        :isapprox,
+    )
     return isapprox_vec(d_ad, d_fd; kwargs...)
 end
 function Base.isapprox(
     d_ad::Tangent{P,<:Tuple}, d_fd::Tangent{P,<:Tuple}; kwargs...
 ) where {P<:Tuple}
+    Base.depwarn(
+        "isapprox is deprecated on AbstractTangents and will be removed. " *
+        "Restructure testing code to use `ChainRulesTestUtils.test_approx` instead.",
+        :isapprox,
+    )
     return isapprox_vec(d_ad, d_fd; kwargs...)
 end
 
 function Base.isapprox(
     d_ad::Tangent{P,<:NamedTuple{T}}, d_fd::Tangent{P,<:NamedTuple{T}}; kwargs...
 ) where {P,T}
+    Base.depwarn(
+        "isapprox is deprecated on AbstractTangents and will be removed. " *
+        "Restructure testing code to use `ChainRulesTestUtils.test_approx` instead.",
+        :isapprox,
+    )
     return isapprox_vec(d_ad, d_fd; kwargs...)
 end
 
 # Must be for same primal
-Base.isapprox(d_ad::Tangent{P}, d_fd::Tangent{Q}; kwargs...) where {P,Q} = false
+function Base.isapprox(d_ad::Tangent{P}, d_fd::Tangent{Q}; kwargs...) where {P,Q}
+    Base.depwarn(
+        "isapprox is deprecated on AbstractTangents and will be removed. " *
+        "Restructure testing code to use `ChainRulesTestUtils.test_approx` instead.",
+        :isapprox,
+    )
+    return false
+end
 
 ###############################################
 


### PR DESCRIPTION
Even though we don't have a direct replacement, still good to give a warning.