### PR TITLE
test arbitrary functions with `f/rrule`-like API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ChainRulesCore = "0.10"
+ChainRulesCore = "0.10.4"
 Compat = "3"
 FiniteDifferences = "0.12.12"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.7.1"
+version = "0.7.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.7.8"
+version = "0.7.9"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -11,15 +11,15 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "04dd5ce9f9d7b9b14559b00a7eb5be7528f56b82"
+git-tree-sha1 = "d659e42240c2162300b321f05173cab5cc40a5ba"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.10.2"
+version = "0.10.4"
 
 [[ChainRulesTestUtils]]
 deps = ["ChainRulesCore", "Compat", "FiniteDifferences", "LinearAlgebra", "Random", "Test"]
 path = ".."
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.7.5"
+version = "0.7.9"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
@@ -40,10 +40,10 @@ deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocStringExtensions]]
-deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "9d4f64f79012636741cf01133158a54b24924c32"
+deps = ["LibGit2"]
+git-tree-sha1 = "a32185f5428d3986f47c2ab78b1f216d5e6cc96f"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.4"
+version = "0.8.5"
 
 [[Documenter]]
 deps = ["Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
@@ -57,9 +57,9 @@ uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [[FiniteDifferences]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Printf", "Random", "Richardson", "StaticArrays"]
-git-tree-sha1 = "5d448db3b862fb331d20144c2e59c54db69720e0"
+git-tree-sha1 = "bdc9fb1d27a1ccecd2fe8f39c6211524cbe642cb"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.12"
+version = "0.12.13"
 
 [[IOCapture]]
 deps = ["Logging"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,10 @@ makedocs(;
     format=Documenter.HTML(; prettyurls=false, assets=["assets/chainrules.css"]),
     sitename="ChainRulesTestUtils",
     authors="JuliaDiff contributors",
+    pages=[
+        "ChainRulesTestUtils" => "index.md",
+        "API" => "api.md",
+    ],
     strict=true,
     checkdocs=:exports,
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,6 @@
+# API Documentation
+
+```@autodocs
+Modules = [ChainRulesTestUtils]
+Private = false
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -147,8 +147,10 @@ Inserting inappropriate zeros can thus hide errors.
 
 ## Testing AD systems
 
-The gradients computed by AD systems can be tested using `test_rrule` by providing an `rrule_f`/`frule_f` keyword argument.
+The gradients computed by AD systems can be also be tested using `test_rrule`.
+To do that, one needs to provide an `rrule_f`/`frule_f` keyword argument, as well as the `RuleConfig` used by the AD system.
 `rrule_f` is a function that wraps the gradient computation by an AD system in the same API as the `rrule`.
+`RuleConfig` is an object that determines which sets of rules are defined for an AD system.
 For example, let's say we have a complicated function
 
 ```julia
@@ -179,9 +181,10 @@ end
 custom2cr(differential) = ...
 cr2custom(differential) = ...
 ```
-Secondly, we use the `test_rrule` function to test the gradients
+Secondly, we use the `test_rrule` function to test the gradients using the config used by the AD system
 ```julia
-test_rrule(complicated, 2.3, 6.1; rrule_f=ad_rrule)
+config = MyAD.CustomRuleConfig()
+test_rrule(config, complicated, 2.3, 6.1; rrule_f=ad_rrule)
 ```
 by specifying the `ad_rrule` as the `rrule_f` keyword argument.
 

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -36,6 +36,7 @@ include("iterator.jl")
 include("output_control.jl")
 include("check_result.jl")
 
+include("rule_config.jl")
 include("finite_difference_calls.jl")
 include("testers.jl")
 

--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -30,8 +30,8 @@ for (T1, T2) in ((AbstractThunk, Any), (AbstractThunk, AbstractThunk), (Any, Abs
     end
 end
 
-test_approx(::ZeroTangent, x, msg=""; kwargs...) = test_approx(zero(x), x, msg; kwargs...)
-test_approx(x, ::ZeroTangent, msg=""; kwargs...) = test_approx(x, zero(x), msg; kwargs...)
+test_approx(::AbstractZero, x, msg=""; kwargs...) = test_approx(zero(x), x, msg; kwargs...)
+test_approx(x, ::AbstractZero, msg=""; kwargs...) = test_approx(x, zero(x), msg; kwargs...)
 test_approx(x::ZeroTangent, y::ZeroTangent, msg=""; kwargs...) = @test true
 
 # remove once https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/113

--- a/src/rule_config.jl
+++ b/src/rule_config.jl
@@ -1,0 +1,16 @@
+# For testing this config re-dispatches Xrule_via_ad to Xrule without config argument
+struct ADviaRuleConfig <: RuleConfig{Union{HasReverseMode, HasForwardsMode}} end
+
+function ChainRulesCore.frule_via_ad(config::ADviaRuleConfig, ȧrgs, f, args...; kws...)
+    ret = frule(config, ȧrgs, f, args...; kws...)
+    # we don't support actually doing AD: the rule has to exist. lets give helpfulish error
+    ret === nothing && throw(MethodError(frule, (ȧrgs, f, args...)))
+    return ret
+end
+
+function ChainRulesCore.rrule_via_ad(config::ADviaRuleConfig, f, args...; kws...)
+    ret = rrule(config, f, args...; kws...)
+    # we don't support actually doing AD: the rule has to exist. lets give helpfulish error
+    ret === nothing && throw(MethodError(rrule, (f, args...)))
+    return ret
+end

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -205,7 +205,7 @@ function test_rrule(
             _test_inferred(rrule_f, config, primals...; fkwargs...)
         end
         res = rrule_f(config, primals...; fkwargs...)
-        res === nothing && throw(MethodError(rrule_f, typeof((primals...))))
+        res === nothing && throw(MethodError(rrule_f, typeof(primals)))
         y_ad, pullback = res
         y = call(primals...)
         test_approx(y_ad, y; isapprox_kwargs...)  # make sure primal is correct

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -158,6 +158,7 @@ function test_rrule(
     inputs...;
     output_tangent=Auto(),
     fdm=_fdm,
+    rrule_f=ChainRulesCore.rrule,
     check_inferred::Bool=true,
     fkwargs::NamedTuple=NamedTuple(),
     rtol::Real=1e-9,
@@ -175,10 +176,10 @@ function test_rrule(
         xs = primal.(xx̄s)
         accumulated_x̄ = tangent.(xx̄s)
         if check_inferred && _is_inferrable(f, xs...; fkwargs...)
-            _test_inferred(rrule, f, xs...; fkwargs...)
+            _test_inferred(rrule_f, f, xs...; fkwargs...)
         end
-        res = rrule(f, xs...; fkwargs...)
-        res === nothing && throw(MethodError(rrule, typeof((f, xs...))))
+        res = rrule_f(f, xs...; fkwargs...)
+        res === nothing && throw(MethodError(rrule_f, typeof((f, xs...))))
         y_ad, pullback = res
         y = f(xs...; fkwargs...)
         test_approx(y_ad, y; isapprox_kwargs...)  # make sure primal is correct

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -53,6 +53,11 @@ function ChainRulesCore.frule((Δf, Δx), f::Foo, x)
     return f(x), Δf.a + Δx
 end
 
+# testing configs
+abstract type MySpecialTrait end
+struct MySpecialConfig <: RuleConfig{Union{MySpecialTrait}} end
+
+
 @testset "testers.jl" begin
     @testset "test_scalar" begin
         @testset "Ensure correct rules succeed" begin
@@ -625,9 +630,6 @@ end
     end
 
     @testset "custom_config" begin
-        abstract type MySpecialTrait end
-        struct MySpecialConfig <: RuleConfig{Union{MySpecialTrait}} end
-
         has_config(x) = 2x
         function ChainRulesCore.rrule(::MySpecialConfig, ::typeof(has_config), x)
             has_config_pullback(ȳ) = return (NoTangent(), 2ȳ)

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -530,4 +530,29 @@ end
         test_frule(f_notimplemented, randn(), randn())
         test_rrule(f_notimplemented, randn(), randn())
     end
+
+    @testset "custom rrule_f" begin
+        only2x(x, y) = 2x
+        custom(::typeof(only2x), x, y) = only2x(x, y), Δ -> (NoTangent(), 2Δ, ZeroTangent())
+        wrong1(::typeof(only2x), x, y) = only2x(x, y), Δ -> (ZeroTangent(), 2Δ, ZeroTangent())
+        wrong2(::typeof(only2x), x, y) = only2x(x, y), Δ -> (NoTangent(), 2.1Δ, ZeroTangent())
+        wrong3(::typeof(only2x), x, y) = only2x(x, y), Δ -> (NoTangent(), 2Δ)
+
+        test_rrule(only2x, 2.0, 3.0; rrule_f=custom, check_inferred=false)
+        @test fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong1, check_inferred=false))
+        @test fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong2, check_inferred=false))
+        @test fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong3, check_inferred=false))
+    end
+
+    @testset "custom frule_f" begin
+        mytuple(x, y) = return 2x, 1.0
+        T = Tuple{Float64, Float64}
+        custom((Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2Δx, ZeroTangent())
+        wrong1((Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2.1Δx, ZeroTangent())
+        wrong2((Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2Δx, 1.0)
+
+        test_frule(mytuple, 2.0, 3.0; frule_f=custom, check_inferred=false)
+        @test fails(() -> test_frule(mytuple, 2.0, 3.0; frule_f=wrong1, check_inferred=false))
+        @test fails(() -> test_frule(mytuple, 2.0, 3.0; frule_f=wrong2, check_inferred=false))
+    end
 end

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -607,7 +607,7 @@ end
         wrong3(::typeof(only2x), x, y) = only2x(x, y), Δ -> (NoTangent(), 2Δ)
 
         test_rrule(only2x, 2.0, 3.0; rrule_f=custom, check_inferred=false)
-        @test fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong1, check_inferred=false))
+        @test errors(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong1, check_inferred=false))
         @test fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong2, check_inferred=false))
         @test fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong3, check_inferred=false))
     end

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -541,7 +541,7 @@ end
         test_rrule(only2x, 2.0, 3.0; rrule_f=custom, check_inferred=false)
         @test fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong1, check_inferred=false))
         @test fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong2, check_inferred=false))
-        @test_broken fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong3, check_inferred=false))
+        @test fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong3, check_inferred=false))
     end
 
     @testset "custom frule_f" begin

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -541,15 +541,15 @@ end
         test_rrule(only2x, 2.0, 3.0; rrule_f=custom, check_inferred=false)
         @test fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong1, check_inferred=false))
         @test fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong2, check_inferred=false))
-        @test fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong3, check_inferred=false))
+        @test_broken fails(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong3, check_inferred=false))
     end
 
     @testset "custom frule_f" begin
         mytuple(x, y) = return 2x, 1.0
         T = Tuple{Float64, Float64}
-        custom((Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2Δx, ZeroTangent())
-        wrong1((Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2.1Δx, ZeroTangent())
-        wrong2((Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2Δx, 1.0)
+        custom((Δf, Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2Δx, ZeroTangent())
+        wrong1((Δf, Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2.1Δx, ZeroTangent())
+        wrong2((Δf, Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2Δx, 1.0)
 
         test_frule(mytuple, 2.0, 3.0; frule_f=custom, check_inferred=false)
         @test fails(() -> test_frule(mytuple, 2.0, 3.0; frule_f=wrong1, check_inferred=false))

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -601,10 +601,10 @@ end
 
     @testset "custom rrule_f" begin
         only2x(x, y) = 2x
-        custom(::typeof(only2x), x, y) = only2x(x, y), Δ -> (NoTangent(), 2Δ, ZeroTangent())
-        wrong1(::typeof(only2x), x, y) = only2x(x, y), Δ -> (ZeroTangent(), 2Δ, ZeroTangent())
-        wrong2(::typeof(only2x), x, y) = only2x(x, y), Δ -> (NoTangent(), 2.1Δ, ZeroTangent())
-        wrong3(::typeof(only2x), x, y) = only2x(x, y), Δ -> (NoTangent(), 2Δ)
+        custom(::RuleConfig, ::typeof(only2x), x, y) = only2x(x, y), Δ -> (NoTangent(), 2Δ, ZeroTangent())
+        wrong1(::RuleConfig, ::typeof(only2x), x, y) = only2x(x, y), Δ -> (ZeroTangent(), 2Δ, ZeroTangent())
+        wrong2(::RuleConfig, ::typeof(only2x), x, y) = only2x(x, y), Δ -> (NoTangent(), 2.1Δ, ZeroTangent())
+        wrong3(::RuleConfig, ::typeof(only2x), x, y) = only2x(x, y), Δ -> (NoTangent(), 2Δ)
 
         test_rrule(only2x, 2.0, 3.0; rrule_f=custom, check_inferred=false)
         @test errors(() -> test_rrule(only2x, 2.0, 3.0; rrule_f=wrong1, check_inferred=false))
@@ -615,9 +615,9 @@ end
     @testset "custom frule_f" begin
         mytuple(x, y) = return 2x, 1.0
         T = Tuple{Float64, Float64}
-        custom((Δf, Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2Δx, ZeroTangent())
-        wrong1((Δf, Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2.1Δx, ZeroTangent())
-        wrong2((Δf, Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2Δx, 1.0)
+        custom(::RuleConfig, (Δf, Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2Δx, ZeroTangent())
+        wrong1(::RuleConfig, (Δf, Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2.1Δx, ZeroTangent())
+        wrong2(::RuleConfig, (Δf, Δx, Δy), ::typeof(mytuple), x, y) = mytuple(x, y), Tangent{T}(2Δx, 1.0)
 
         test_frule(mytuple, 2.0, 3.0; frule_f=custom, check_inferred=false)
         @test fails(() -> test_frule(mytuple, 2.0, 3.0; frule_f=wrong1, check_inferred=false))


### PR DESCRIPTION
Closes #114
Closes #173

To do:
- [x] tests for passing in `xrule_f`
- [x] tests for config
- [x] documentation
- [x] [implement an actual `rrule_f` example in Zygote](https://github.com/FluxML/Zygote.jl/pull/987) to test real examples
- [x] think about matching requirements for `f/rrule_via_ad`
- [x] decide whether to define `test_approx(NoTangent, x) = test_approx(zero(x), x)`
- [x] wait for [configs](https://github.com/JuliaDiff/ChainRulesCore.jl/pull/363) to be merged and tagged, and update compat