### PR TITLE
Make work on functors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,5 +13,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 ChainRulesCore = "0.10"
 Compat = "3"
-FiniteDifferences = "0.12"
+FiniteDifferences = "0.12.12"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -57,7 +57,7 @@ uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [[FiniteDifferences]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Printf", "Random", "Richardson", "StaticArrays"]
-path = "../dev/FiniteDifferences"
+git-tree-sha1 = "5d448db3b862fb331d20144c2e59c54db69720e0"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
 version = "0.12.12"
 

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -11,15 +11,15 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "5d64be50ea9b43a89b476be773e125cef03c7cd5"
+git-tree-sha1 = "04dd5ce9f9d7b9b14559b00a7eb5be7528f56b82"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.10.1"
+version = "0.10.2"
 
 [[ChainRulesTestUtils]]
 deps = ["ChainRulesCore", "Compat", "FiniteDifferences", "LinearAlgebra", "Random", "Test"]
 path = ".."
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.7.0"
+version = "0.7.5"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
@@ -57,9 +57,9 @@ uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [[FiniteDifferences]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Printf", "Random", "Richardson", "StaticArrays"]
-git-tree-sha1 = "f8c8e287c1d68abc2719ad58fb39de9f6c0d71b1"
+path = "../dev/FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.10"
+version = "0.12.12"
 
 [[IOCapture]]
 deps = ["Logging"]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -105,6 +105,29 @@ Test Summary:             | Pass  Total
 test_scalar: relu at -0.5 |    9      9
 ```
 
+## Testing constructors and functors (callable objects)
+
+Testing constructor and functors works as you would expect. For struct `Foo`
+```julia
+struct Foo
+    a::Float64
+end
+(f::Foo)(x) = return f.a + x
+Base.length(::Foo) = 1
+Base.iterate(f::Foo) = iterate(f.a)
+Base.iterate(f::Foo, state) = iterate(f.a, state)
+```
+the `f/rrule`s can be tested by
+```julia
+test_rrule(Foo, rand()) # constructor
+
+foo = Foo(rand())
+test_rrule(foo, rand()) # functor
+
+# it is also possible to provide tangents for `foo` explicitly
+test_frule(foo ⊢ Tangent{Foo}(;a=rand()), rand())
+```
+
 ## Specifying Tangents
 [`test_frule`](@ref) and [`test_rrule`](@ref) allow you to specify the tangents used for testing.
 This is done by passing in `x ⊢ Δx`, where `x` is the primal and `Δx` is the tangent, in the place of the primal inputs.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -105,29 +105,6 @@ Test Summary:             | Pass  Total
 test_scalar: relu at -0.5 |    9      9
 ```
 
-## Testing constructors and functors (callable objects)
-
-Testing constructor and functors works as you would expect. For struct `Foo`
-```julia
-struct Foo
-    a::Float64
-end
-(f::Foo)(x) = return f.a + x
-Base.length(::Foo) = 1
-Base.iterate(f::Foo) = iterate(f.a)
-Base.iterate(f::Foo, state) = iterate(f.a, state)
-```
-the `f/rrule`s can be tested by
-```julia
-test_rrule(Foo, rand()) # constructor
-
-foo = Foo(rand())
-test_rrule(foo, rand()) # functor
-
-# it is also possible to provide tangents for `foo` explicitly
-test_frule(foo ⊢ Tangent{Foo}(;a=rand()), rand())
-```
-
 ## Specifying Tangents
 [`test_frule`](@ref) and [`test_rrule`](@ref) allow you to specify the tangents used for testing.
 This is done by passing in `x ⊢ Δx`, where `x` is the primal and `Δx` is the tangent, in the place of the primal inputs.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -175,7 +175,7 @@ which should have passed the test.
 
 By default, all functions for testing rules check whether the output type (as well as that of the pullback for `rrule`s) can be completely inferred, such that everything is type stable:
 
-```jldoctest ex
+```julia
 julia> function ChainRulesCore.rrule(::typeof(abs), x)
            abs_pullback(Δ) = (NoTangent(), x >= 0 ? Δ : big(-1.0) * Δ)
            return abs(x), abs_pullback
@@ -190,7 +190,7 @@ test_rrule: abs on Float64: Error During Test at /home/runner/work/ChainRulesTes
 
 This can be disabled on a per-rule basis using the `check_inferred` keyword argument:
 
-```jldoctest ex
+```julia
 julia> test_rrule(abs, 1.; check_inferred=false)
 Test Summary:              | Pass  Total
 test_rrule: abs on Float64 |    5      5

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -18,7 +18,6 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
     isapprox_kwargs = (; rtol=rtol, atol=atol, kwargs...)
 
     @testset "test_scalar: $f at $z" begin
-        _ensure_not_running_on_functor(f, "test_scalar")
         # z = x + im * y
         # Ω = u(x, y) + im * v(x, y)
         Ω = f(z; fkwargs...)
@@ -30,8 +29,9 @@ function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(),
             test_frule(f, z ⊢ Δx; rule_test_kwargs...)
             if z isa Complex
                 # check that same tangent is produced for tangent 1.0 and 1.0 + 0.0im
-                _, real_tangent = frule((ZeroTangent(), real(Δx)), f, z; fkwargs...)
-                _, embedded_tangent = frule((ZeroTangent(), Δx), f, z; fkwargs...)
+                ḟ = rand_tangent(f)
+                _, real_tangent = frule((ḟ, real(Δx)), f, z; fkwargs...)
+                _, embedded_tangent = frule((ḟ, Δx), f, z; fkwargs...)
                 test_approx(real_tangent, embedded_tangent; isapprox_kwargs...)
             end
         end

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -224,7 +224,7 @@ function test_rrule(
             if accum_cotangent isa Union{Nothing,NoTangent}  # then we marked this argument as not differentiable # TODO remove once #113
                 @assert fd_cotangent === nothing  # this is how `_make_j′vp_call` works
                 ad_cotangent isa ZeroTangent && error(
-                    "The pullback in the rrule for $func function should use NoTangent()" *
+                    "The pullback in the rrule should use NoTangent()" *
                     " rather than ZeroTangent() for non-perturbable arguments.",
                 )
                 @test ad_cotangent isa NoTangent  # we said it wasn't differentiable.

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -206,9 +206,17 @@ function test_rrule(
             )
         end
 
-        fd_cotangents = _make_j′vp_call(fdm, (f, xs...) -> f(xs...; fkwargs...), ȳ, (f, xs...), is_ignored)
+        fd_cotangents = _make_j′vp_call(
+            fdm,
+            (f, xs...) -> f(xs...; fkwargs...),
+            ȳ,
+            (f, xs...),
+            is_ignored
+        )
 
-        for (accum_cotangent, ad_cotangent, fd_cotangent) in zip(accum_cotangents, ad_cotangents, fd_cotangents)
+        for (accum_cotangent, ad_cotangent, fd_cotangent) in zip(
+            accum_cotangents, ad_cotangents, fd_cotangents
+        )
             if accum_cotangent isa Union{Nothing,NoTangent}  # then we marked this argument as not differentiable # TODO remove once #113
                 @assert fd_cotangent === nothing  # this is how `_make_j′vp_call` works
                 ad_cotangent isa ZeroTangent && error(
@@ -219,7 +227,7 @@ function test_rrule(
             else
                 ad_cotangent isa AbstractThunk && check_inferred && _test_inferred(unthunk, ad_cotangent)
 
-                # The main test of the actual deriviative being correct:
+                # The main test of the actual derivative being correct:
                 test_approx(ad_cotangent, fd_cotangent; isapprox_kwargs...)
                 _test_add!!_behaviour(accum_cotangent, ad_cotangent; isapprox_kwargs...)
             end

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -150,7 +150,7 @@ end
     Non-differentiable arguments, such as indices, should have `x̄` set as `NoTangent()`.
 
 # Keyword Arguments
- - `output_tangent` the seed to propagate backward for testing (techncally a cotangent).
+ - `output_tangent` the seed to propagate backward for testing (technically a cotangent).
    should be a differential for the output of `f`. Is set automatically if not provided.
  - `fdm::FiniteDifferenceMethod`: the finite differencing method to use.
  - If `check_inferred=true`, then the inferrability of the `rrule` is checked

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -70,7 +70,7 @@ end
     test_frule(f, args..; kwargs...)
 
 # Arguments
-- `f`: Function for which the `frule` should be tested.
+- `f`: Function for which the `frule` should be tested. Can also provide `f ⊢ ḟ`.
 - `args` either the primal args `x`, or primals and their tangents: `x ⊢ ẋ`
    - `x`: input at which to evaluate `f` (should generally be set to an arbitary point in the domain).
    - `ẋ`: differential w.r.t. `x`, will be generated automatically if not provided
@@ -149,8 +149,8 @@ end
     test_rrule(f, args...; kwargs...)
 
 # Arguments
-- `f`: Function to which rule should be applied.
-- `args` either the primal args `x`, or primals and their tangents: `x ⊢ ẋ`
+- `f`: Function to which rule should be applied. Can also provide `f ⊢ f̄`.
+- `args` either the primal args `x`, or primals and their tangents: `x ⊢ x̄`
     - `x`: input at which to evaluate `f` (should generally be set to an arbitary point in the domain).
     - `x̄`: currently accumulated cotangent, will be generated automatically if not provided
     Non-differentiable arguments, such as indices, should have `x̄` set as `NoTangent()`.

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -246,16 +246,6 @@ function check_thunking_is_appropriate(x̄s)
     end
 end
 
-function _ensure_not_running_on_functor(f, name)
-    # if x itself is a Type, then it is a constructor, thus not a functor.
-    # This also catchs UnionAll constructors which have a `:var` and `:body` fields
-    f isa Type && return nothing
-
-    if fieldcount(typeof(f)) > 0
-        throw(ArgumentError("$name cannot be used on closures/functors (such as $f)"))
-    end
-end
-
 """
     _test_inferred(f, args...; kwargs...)
 

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -188,7 +188,7 @@ function test_rrule(
         res = rrule(func, xs...; fkwargs...)
         res === nothing && throw(MethodError(rrule, typeof((func, xs...))))
         y_ad, pullback = res
-        y = f(xs...; fkwargs...)
+        y = func(xs...; fkwargs...)
         test_approx(y_ad, y; isapprox_kwargs...)  # make sure primal is correct
 
         ȳ = output_tangent isa Auto ? rand_tangent(y) : output_tangent

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -104,7 +104,7 @@ function test_frule(
         xs = primal.(xẋs)
         tangents = (rand_tangent(f), tangent.(xẋs)...)
         if check_inferred && _is_inferrable(f, deepcopy(xs)...; deepcopy(fkwargs)...)
-            _test_inferred(frule, (deepcopy(tangents)...), f, deepcopy(xs)...; deepcopy(fkwargs)...)
+            _test_inferred(frule, (deepcopy(tangents)...,), f, deepcopy(xs)...; deepcopy(fkwargs)...)
         end
         res = frule(deepcopy(tangents), f, deepcopy(xs)...; deepcopy(fkwargs)...)
         res === nothing && throw(MethodError(frule, typeof((f, xs...))))

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -552,10 +552,16 @@ end
         end
 
         foo = Foo(rand())
+        tfoo = Tangent{Foo}(;a=rand())
         @testset "functor" begin
             test_frule(foo, rand())
             test_rrule(foo, rand())
             test_scalar(foo, rand())
+
+            test_frule(foo ⊢ Foo(rand()), rand())
+            test_frule(foo ⊢ tfoo, rand())
+            test_rrule(foo ⊢ Foo(rand()), rand())
+            test_rrule(foo ⊢ tfoo, rand())
         end
     end
 

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -25,6 +25,9 @@ struct Foo
     a::Float64
 end
 (f::Foo)(x, y) = return f.a + x + y
+Base.length(::Foo) = 1
+Base.iterate(f::Foo) = iterate(f.a)
+Base.iterate(f::Foo, state) = iterate(f.a, state)
 
 # constructor
 function ChainRulesCore.rrule(::Type{Foo}, a)
@@ -34,6 +37,9 @@ function ChainRulesCore.rrule(::Type{Foo}, a)
     end
     return foo, Foo_pullback
 end
+function ChainRulesCore.frule((_, Δy), ::Type{Foo}, y)
+    return Foo(y), Foo(Δy)
+end
 
 # functor
 function ChainRulesCore.rrule(f::Foo, x, y)
@@ -42,6 +48,9 @@ function ChainRulesCore.rrule(f::Foo, x, y)
         return Tangent{Foo}(;a=Δy), Δy, Δy
     end
     return y, Foo_pullback
+end
+function ChainRulesCore.frule((Δf, Δx, Δy), f::Foo, x, y)
+    return f(x, y), Δf.a + Δx + Δy
 end
 
 @testset "testers.jl" begin


### PR DESCRIPTION
Closes #117 

To do:
- [x] merge and tag [FiniteDifferences PR](https://github.com/JuliaDiff/FiniteDifferences.jl/pull/172), add compat. Needed to generate `rand_tangent` for `f` when testing constructors, i.e. `rand_tangent(Foo)`
- [x] implement `test_frule` for functors
- [x] implement `test_scalar` for functors
- [x] remove `_ensure_not_running_on_functor`