### PR TITLE
WIP: test all tangents

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.7.9"
+version = "0.7.10"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -13,6 +13,7 @@ import FiniteDifferences: rand_tangent
 
 const _fdm = central_fdm(5, 1; max_range=1e-2)
 const TEST_INFERRED = Ref(true)
+const TRANSFORMS_TO_TEST_TANGENTS = Ref{Vector{Function}}([identity, ])
 
 export TestIterator
 export test_approx, test_scalar, test_frule, test_rrule, generate_well_conditioned_matrix

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -110,8 +110,8 @@ function test_frule(
         primals = primal.(primals_and_tangents)
         tangents = tangent.(primals_and_tangents)
 
-        for tangent_transform in tangent_transforms
-            these_tangents = tangent_transform.(tangents)
+        @testset "for ȧrgs $(_string_typeof(tsf.(tangents)))" for tsf in tangent_transforms
+            these_tangents = tsf.(tangents)
 
             if check_inferred && _is_inferrable(deepcopy(primals)...; deepcopy(fkwargs)...)
                 _test_inferred(frule, deepcopy(these_tangents), deepcopy(primals)...; deepcopy(fkwargs)...)


### PR DESCRIPTION
part of #159 (need a breaking version to actually test all tangents by changing `TRANSFORMS_TO_TEST_TANGENTS`)

Might do this, or might just test that passing a different tangent to pullback does not error (and not check correctness using finite differencing)

The test runtime would scale linearly with the number of tangents if we do this PR. If finite differencing dominates (does it?) In that case just testing the pullbacks would have no performance impact.

- [ ] variables names tbc
- [ ] do this or just test pullback?