### PR TITLE
do not check for thunks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.7.7"
+version = "0.7.8"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -229,18 +229,7 @@ function test_rrule(
                 _test_add!!_behaviour(accum_cotangent, ad_cotangent; isapprox_kwargs...)
             end
         end
-
-        check_thunking_is_appropriate(ad_cotangents)
     end  # top-level testset
-end
-
-function check_thunking_is_appropriate(x̄s)
-    num_zeros = count(x -> x isa AbstractZero, x̄s)
-    num_thunks = count(x -> x isa Thunk, x̄s)
-    if num_zeros + num_thunks == length(x̄s)
-        # num_thunks can be either 0, or greater than 1.
-        @test_msg "Should not thunk only non_zero argument" num_thunks != 1
-    end
 end
 
 """


### PR DESCRIPTION
This was there to prevent overthunking, but fails for some cases where thunking is useful. The instructions on when to thunk are in the docs