### PR TITLE
Shorten testset names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "0.7.10"
+version = "0.7.11"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -165,7 +165,7 @@ function _test_frule_alt_tangents(
     call, frule_f, config, tangent_transforms, tangents, primals, acc;
     isapprox_kwargs...
 )
-    @testset "ȧrgs = $(tsf.(tangents))" for tsf in tangent_transforms
+    @testset "ȧrgs = $(_string_typeof(tsf.(tangents)))" for tsf in tangent_transforms
         _, dΩ = call(frule_f, config, tsf.(tangents), primals...)
         _test_add!!_behaviour(acc, dΩ; isapprox_kwargs...)
     end
@@ -289,7 +289,7 @@ function _test_rrule_alt_tangents(
     pullback, tangent_transforms, ȳ, accum_cotangents;
     isapprox_kwargs...
 )
-    @testset "ȳ = $(tsf(ȳ))" for tsf in tangent_transforms
+    @testset "ȳ = $(_string_typeof(tsf(ȳ)))" for tsf in tangent_transforms
         ad_cotangents = pullback(tsf(ȳ))
         for (accum_cotangent, ad_cotangent) in zip(accum_cotangents, ad_cotangents)
             _test_add!!_behaviour(accum_cotangent, ad_cotangent; isapprox_kwargs...)


### PR DESCRIPTION
Shortens the testset names for alternative tangents. Did not notice in the original PR since all the tests passed.