### PR TITLE
Add public API to enable testing on thunks

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -11,9 +11,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "dbc9aae1227cfddaa9d2552f3ecba5b641f6cce9"
+git-tree-sha1 = "be770c08881f7bb928dfd86d1ba83798f76cf62a"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.10.5"
+version = "0.10.9"
 
 [[ChainRulesTestUtils]]
 deps = ["ChainRulesCore", "Compat", "FiniteDifferences", "LinearAlgebra", "Random", "Test"]
@@ -23,9 +23,9 @@ version = "0.7.12"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "e4e2b39db08f967cc1360951f01e8a75ec441cab"
+git-tree-sha1 = "dc7dedc2c2aa9faf59a55c622760a25cbefbe941"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.30.0"
+version = "3.31.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -47,9 +47,9 @@ version = "0.8.5"
 
 [[Documenter]]
 deps = ["Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "5acbebf1be22db43589bc5aa1bb5fcc378b17780"
+git-tree-sha1 = "621850838b3e74dd6dd047b5432d2e976877104e"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.27.0"
+version = "0.27.2"
 
 [[Downloads]]
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
@@ -167,9 +167,9 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "42378d3bab8b4f57aa1ca443821b752850592668"
+git-tree-sha1 = "745914ebcd610da69f3cb6bf76cb7bb83dcb8c9a"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.2"
+version = "1.2.4"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -4,3 +4,9 @@
 Modules = [ChainRulesTestUtils]
 Private = false
 ```
+
+
+## Global Configuration
+```@docs
+ChainRulesTestUtils.enable_tangent_transform!
+```

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -11,24 +11,14 @@ using Test
 
 import FiniteDifferences: rand_tangent
 
-const _fdm = central_fdm(5, 1; max_range=1e-2)
-const TEST_INFERRED = Ref(true)
-const TRANSFORMS_TO_ALT_TANGENTS = Function[] # e.g. [x -> @thunk(x), _ -> ZeroTangent(), x -> rebasis(x)]
-
 export TestIterator
 export test_approx, test_scalar, test_frule, test_rrule, generate_well_conditioned_matrix
 export ⊢
 export @maybe_inferred
 
-function __init__()
-    TEST_INFERRED[] = if haskey(ENV, "CHAINRULES_TEST_INFERRED")
-        parse(Bool, "CHAINRULES_TEST_INFERRED")
-    else
-        !parse(Bool, get(ENV, "JULIA_PKGEVAL", "false"))
-    end
+__init__() = init_test_inferred_setting!()
 
-    !TEST_INFERRED[] && @warn "inference tests have been disabled"
-end
+include("global_config.jl")
 
 include("generate_tangent.jl")
 include("data_generation.jl")

--- a/src/global_config.jl
+++ b/src/global_config.jl
@@ -1,0 +1,16 @@
+const _fdm = central_fdm(5, 1; max_range=1e-2)
+const TEST_INFERRED = Ref(true)
+const TRANSFORMS_TO_ALT_TANGENTS = Function[] # e.g. [x -> @thunk(x), _ -> ZeroTangent(), x -> rebasis(x)]
+
+
+
+"sets up TEST_INFERRED based ion enviroment variables"
+function init_test_inferred_setting!()
+    TEST_INFERRED[] = if haskey(ENV, "CHAINRULES_TEST_INFERRED")
+        parse(Bool, "CHAINRULES_TEST_INFERRED")
+    else
+        !parse(Bool, get(ENV, "JULIA_PKGEVAL", "false"))
+    end
+
+    !TEST_INFERRED[] && @warn "inference tests have been disabled"
+end

--- a/src/global_config.jl
+++ b/src/global_config.jl
@@ -2,7 +2,27 @@ const _fdm = central_fdm(5, 1; max_range=1e-2)
 const TEST_INFERRED = Ref(true)
 const TRANSFORMS_TO_ALT_TANGENTS = Function[] # e.g. [x -> @thunk(x), _ -> ZeroTangent(), x -> rebasis(x)]
 
+"""
+    enable_tangent_transform!(Thunk)
 
+Adds a alt-tangent tranform to the list of default `tangent_transforms` for
+[`test_frule`](@ref) and [`test_rrule`](@ref) to test.
+This list of defaults is overwritten by the `tangent_transforms` keyword argument.
+
+!!! info "Transitional Feature"
+    ChainRulesCore v1.0 will require that all well-behaved rules work for a variety of
+    tangent representations. In turn, the corresponding release of ChainRulesTestUtils will 
+    test all the different tangent representations by default.
+    At that stage `enable_tangent_transform!(Thunk)` will have no effect, as it will already 
+    be enabled.
+    We provide this configuration as a transitional feature to help migrate your packages
+    one feature at a time, prior to the breaking release of ChainRulesTestUtils that will
+    enforce it.  
+"""
+function enable_tangent_transform!(::Type{Thunk})
+    push!(TRANSFORMS_TO_ALT_TANGENTS, x->@thunk(x))
+    unique!(TRANSFORMS_TO_ALT_TANGENTS)
+end
 
 "sets up TEST_INFERRED based ion enviroment variables"
 function init_test_inferred_setting!()

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -316,7 +316,7 @@ end
 """
     _test_inferred(f, args...; kwargs...)
 
-Simple wrapper for `@inferred f(args...: kwargs...)`, avoiding the type-instability in not
+Simple wrapper for [`@maybe_inferred f(args...: kwargs...)`](@ref `@maybe_inferred`), avoiding the type-instability in not
 knowing how many `kwargs` there are.
 """
 function _test_inferred(f, args...; kwargs...)


### PR DESCRIPTION
per @stevengj suggestion here https://github.com/JuliaMath/SpecialFunctions.jl/pull/329#discussion_r658363734

Best to review this one commit at a time
 - first commit just moves things
 - second commit adds the headline feature
 

This also resolves #182 since now we can use `unique` as it will be the same function

[Docs Preview](https://juliadiff.org/ChainRulesTestUtils.jl/previews/PR183/api.html#Global-Configuration)
I think we could do with more docs on global config (e.g. re-inference testing) but out of scope for this issue
 