### PR TITLE
use ProjectTo for rand_tangent, and also catch some more places we shoud NoTangent

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ChainRulesCore = "0.10.12, 1"
+ChainRulesCore = "1"
 Compat = "3"
 FiniteDifferences = "0.12.12"
 julia = "1"

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -30,7 +30,7 @@ end
 rand_tangent(rng::AbstractRNG, ::BigFloat) = round(big(9 * randn(rng)), sigdigits=5, base=2)
 
 
-rand_tangent(rng::AbstractRNG, x::Array{<:Any, 0}) = _compress_notangent(fill(rand_tangent(x[])))
+rand_tangent(rng::AbstractRNG, x::Array{<:Any, 0}) = _compress_notangent(fill(rand_tangent(rng, x[])))
 rand_tangent(rng::AbstractRNG, x::Array) = _compress_notangent(rand_tangent.(Ref(rng), x))
 
 # All other AbstractArray's can be handled using the ProjectTo mechanics.

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -36,7 +36,7 @@ rand_tangent(rng::AbstractRNG, x::Array) = _compress_notangent(rand_tangent.(Ref
 # All other AbstractArray's can be handled using the ProjectTo mechanics.
 # and follow the same requirements
 function rand_tangent(rng::AbstractRNG, x::AbstractArray)
-    return _compress_notangent(ProjectTo(x)(rand_tangent(collect(x))))
+    return _compress_notangent(ProjectTo(x)(rand_tangent(rng, collect(x))))
 end
 
 # TODO: arguably ProjectTo should handle this for us for AbstactArrays

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -29,18 +29,20 @@ end
 # multiply by 9 to give a bigger range of values tested: no so tightly clustered around 0.
 rand_tangent(rng::AbstractRNG, ::BigFloat) = round(big(9 * randn(rng)), sigdigits=5, base=2)
 
-rand_tangent(rng::AbstractRNG, x::StridedArray{T, 0}) where {T} = fill(rand_tangent(x[1]))
-rand_tangent(rng::AbstractRNG, x::StridedArray) = rand_tangent.(Ref(rng), x)
-rand_tangent(rng::AbstractRNG, x::Adjoint) = adjoint(rand_tangent(rng, parent(x)))
-rand_tangent(rng::AbstractRNG, x::Transpose) = transpose(rand_tangent(rng, parent(x)))
 
-function rand_tangent(rng::AbstractRNG, x::T) where {T<:Tuple}
-    return Tangent{T}(rand_tangent.(Ref(rng), x)...)
+rand_tangent(rng::AbstractRNG, x::Array{<:Any, 0}) = _compress_notangent(fill(rand_tangent(x[])))
+rand_tangent(rng::AbstractRNG, x::Array) = _compress_notangent(rand_tangent.(Ref(rng), x))
+
+# All other AbstractArray's can be handled using the ProjectTo mechanics.
+# and follow the same requirements
+function rand_tangent(rng::AbstractRNG, x::AbstractArray)
+    return _compress_notangent(ProjectTo(x)(rand_tangent(collect(x))))
 end
 
-function rand_tangent(rng::AbstractRNG, xs::T) where {T<:NamedTuple}
-    return Tangent{T}(; map(x -> rand_tangent(rng, x), xs)...)
-end
+# TODO: arguably ProjectTo should handle this for us for AbstactArrays
+# https://github.com/JuliaDiff/ChainRulesCore.jl/issues/410
+_compress_notangent(::AbstractArray{NoTangent}) = NoTangent()
+_compress_notangent(x) = x
 
 function rand_tangent(rng::AbstractRNG, x::T) where {T}
     if !isstructtype(T)
@@ -54,8 +56,12 @@ function rand_tangent(rng::AbstractRNG, x::T) where {T}
     if all(tangent isa NoTangent for tangent in tangents)
         # if none of my fields can be perturbed then I can't be perturbed
         return NoTangent()
+    end
+
+    if T <: Tuple
+        return Tangent{T}(tangents...)
     else
-        Tangent{T}(; NamedTuple{field_names}(tangents)...)
+        return Tangent{T}(; NamedTuple{field_names}(tangents)...)
     end
 end
 

--- a/test/rand_tangent.jl
+++ b/test/rand_tangent.jl
@@ -69,6 +69,7 @@ struct Bar
         (sin, NoTangent),
         # all fields NoTangent implies NoTangent
         (Pair(:a, "b"), NoTangent),
+        (CartesianIndex(2, 3), NoTangent),
 
         # LinearAlgebra types
         (

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using ChainRulesCore
 using ChainRulesTestUtils
+using ChainRulesTestUtils: rand_tangent
 using FiniteDifferences
 using LinearAlgebra
 using Random


### PR DESCRIPTION
 - Changed to using ProjectTo for all AbstractArrays (this is a real functional change)
 - found that that wasn't compressing all NoTangents: see https://github.com/JuliaDiff/ChainRulesCore.jl/issues/410
- fix that, athen noticed some cases we were not handling that for Tuples/NamedTuples
- fixed those by makign them use the generic struct fallback