### PR TITLE
Use `NoTangent()` instead of `nothing` to designate non-differentiability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/finite_difference_calls.jl
+++ b/src/finite_difference_calls.jl
@@ -19,7 +19,7 @@ function _make_jvp_call(fdm, f, y, xs, ẋs, ignores)
     f2 = _wrap_function(f, xs, ignores)
 
     ignores = collect(ignores)
-    all(ignores) && return ntuple(_ -> nothing, length(xs))
+    all(ignores) && return NoTangent()
     sigargs = zip(xs[.!ignores], ẋs[.!ignores])
     return _maybe_fix_to_composite(y, jvp(fdm, f2, sigargs...))
 end
@@ -45,7 +45,7 @@ function _make_j′vp_call(fdm, f, ȳ, xs, ignores)
 
     ignores = collect(ignores)
     args = Any[nothing for _ in 1:length(xs)]
-    all(ignores) && return (args...,)
+    all(ignores) && return NoTangent()
     sigargs = xs[.!ignores]
     arginds = (1:length(xs))[.!ignores]
     fd = j′vp(fdm, f2, ȳ, sigargs...)

--- a/src/finite_difference_calls.jl
+++ b/src/finite_difference_calls.jl
@@ -19,7 +19,7 @@ function _make_jvp_call(fdm, f, y, xs, ẋs, ignores)
     f2 = _wrap_function(f, xs, ignores)
 
     ignores = collect(ignores)
-    all(ignores) && return NoTangent()
+    all(ignores) && return ntuple(_ -> NoTangent(), length(xs))
     sigargs = zip(xs[.!ignores], ẋs[.!ignores])
     return _maybe_fix_to_composite(y, jvp(fdm, f2, sigargs...))
 end
@@ -45,7 +45,7 @@ function _make_j′vp_call(fdm, f, ȳ, xs, ignores)
 
     ignores = collect(ignores)
     args = Any[NoTangent() for _ in 1:length(xs)]
-    all(ignores) && return NoTangent()
+    all(ignores) && return (args...,)
     sigargs = xs[.!ignores]
     arginds = (1:length(xs))[.!ignores]
     fd = j′vp(fdm, f2, ȳ, sigargs...)

--- a/src/finite_difference_calls.jl
+++ b/src/finite_difference_calls.jl
@@ -35,7 +35,7 @@ Call `FiniteDifferences.j′vp`, with the option to ignore certain `xs`.
 - `ȳ`: The adjoint w.r.t. output of `f`.
 - `xs`: Inputs to `f`, such that `y = f(xs...)`.
 - `ignores`: Collection of `Bool`s, the same length as `xs`.
-  If `ignores[i] === true`, then `xs[i]` is ignored; `∂xs[i] === nothing`.
+  If `ignores[i] === true`, then `xs[i]` is ignored; `∂xs[i] === NoTangent()`.
 
 # Returns
 - `∂xs::Tuple`: Derivatives estimated by finite differencing.
@@ -44,7 +44,7 @@ function _make_j′vp_call(fdm, f, ȳ, xs, ignores)
     f2 = _wrap_function(f, xs, ignores)
 
     ignores = collect(ignores)
-    args = Any[nothing for _ in 1:length(xs)]
+    args = Any[NoTangent() for _ in 1:length(xs)]
     all(ignores) && return NoTangent()
     sigargs = xs[.!ignores]
     arginds = (1:length(xs))[.!ignores]
@@ -66,7 +66,7 @@ Return a new version of `f`, `fnew`, that ignores some of the arguments `xs`.
 - `f`: The function to be wrapped.
 - `xs`: Inputs to `f`, such that `y = f(xs...)`.
 - `ignores`: Collection of `Bool`s, the same length as `xs`.
-  If `ignores[i] === true`, then `xs[i]` is ignored; `∂xs[i] === nothing`.
+  If `ignores[i] === true`, then `xs[i]` is ignored; `∂xs[i] === NoTangent()`.
 """
 function _wrap_function(f, xs, ignores)
     function fnew(sigargs...)

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -225,7 +225,7 @@ function test_rrule(
             accum_cotangents, ad_cotangents, fd_cotangents
         )
             if accum_cotangent isa NoTangent  # then we marked this argument as not differentiable
-                @assert fd_cotangent === nothing  # this is how `_make_j′vp_call` works
+                @assert fd_cotangent === NoTangent()
                 ad_cotangent isa ZeroTangent && error(
                     "The pullback in the rrule should use NoTangent()" *
                     " rather than ZeroTangent() for non-perturbable arguments.",


### PR DESCRIPTION
Needed so that https://github.com/JuliaDiff/FiniteDifferences.jl/pull/189 does not break ChainRules tests