### PR TITLE
don't specialize any functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -1,5 +1,7 @@
 module ChainRulesTestUtils
 
+@nospecialize
+
 using ChainRulesCore
 using ChainRulesCore: frule, rrule
 using Compat: only


### PR DESCRIPTION
This takes the time to run the ChainRules test suite from 52 minutes
down to 40 in my tests. I think there are still more gains to be had
here by playing around a bit with `Experimental.@compiler_options`, but
initially that caused some of the inference tests to fail.