### PR TITLE
use digits=5 (not sigdigits) to generate nice random numbers.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -17,7 +17,7 @@ rand_tangent(rng::AbstractRNG, x::Integer) = NoTangent()
 # while also not biasing the sample space too much
 function rand_tangent(rng::AbstractRNG, x::T) where {T<:Number}
     # multiply by 9 to give a bigger range of values tested: no so tightly clustered around 0.
-    return round(9 * randn(rng, T), sigdigits=5, base=2)
+    return round(9 * randn(rng, T), digits=5, base=2)
 end
 rand_tangent(rng::AbstractRNG, x::Float64) = rand(rng, -9:0.01:9)
 function rand_tangent(rng::AbstractRNG, x::ComplexF64)
@@ -27,7 +27,7 @@ end
 #BigFloat/MPFR is finicky about short numbers, this doesn't always work as well as it should
 
 # multiply by 9 to give a bigger range of values tested: no so tightly clustered around 0.
-rand_tangent(rng::AbstractRNG, ::BigFloat) = round(big(9 * randn(rng)), sigdigits=5, base=2)
+rand_tangent(rng::AbstractRNG, ::BigFloat) = round(big(9 * randn(rng)), digits=5, base=2)
 
 
 rand_tangent(rng::AbstractRNG, x::Array{<:Any, 0}) = _compress_notangent(fill(rand_tangent(rng, x[])))

--- a/test/rand_tangent.jl
+++ b/test/rand_tangent.jl
@@ -105,13 +105,13 @@ struct Bar
     end
 
     # Julia 1.6 changed to using Ryu printing algorithm and seems better at printing short
-    VERSION > v"1.6" && @testset "niceness of printing" begin
-        rng = MersenneTwister()
+    VERSION >= v"1.6" && @testset "niceness of printing" begin
+        rng = MersenneTwister(1)
         for i in 1:50
-            @test length(string(rand_tangent(1.0))) <= 6
-            @test length(string(rand_tangent(1.0 + 1.0im))) <= 12
-            @test length(string(rand_tangent(1f0))) <= 12
-            @test length(string(rand_tangent(big"1.0"))) <= 20
+            @test length(string(rand_tangent(rng, 1.0))) <= 6
+            @test length(string(rand_tangent(rng, 1.0 + 1.0im))) <= 12
+            @test length(string(rand_tangent(rng, 1f0))) <= 9
+            @test length(string(rand_tangent(rng, big"1.0"))) <= 9
         end
     end
 end


### PR DESCRIPTION
Fixes #206 

There were 3 problems:
 - `sigdigits` was used rather than `digits` which meant that numbers like `0.0000000000001234` were showing up.
 - the `rng` which was in the test to reduce chance of hitting edge cases unexpectedly wasn't used
 - that `rng` wasn't initialized so didn't actually serve that purpose anyway
 
 I have now run these tests a few million times, rather than the 50 that is there, and it always passes now.