### PR TITLE
Improve docs on testing AD gradients

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -16,21 +16,21 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "f53ca8d41e4753c41cdafa6ec5f7ce914b34be54"
+git-tree-sha1 = "bdc0937269321858ab2a4f288486cb258b9a0af7"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.10.13"
+version = "1.3.0"
 
 [[ChainRulesTestUtils]]
 deps = ["ChainRulesCore", "Compat", "FiniteDifferences", "LinearAlgebra", "Random", "Test"]
 path = ".."
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "1.0.0-DEV"
+version = "1.2.1"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "dc7dedc2c2aa9faf59a55c622760a25cbefbe941"
+git-tree-sha1 = "727e463cfebd0c7b999bbf3e9e7e16f254b94193"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.31.0"
+version = "3.34.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -52,9 +52,9 @@ version = "0.8.5"
 
 [[Documenter]]
 deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "95265abf7d7bf06dfdb8d58525a23ea5fb0bdeee"
+git-tree-sha1 = "350dced36c11f794c6c4da5dc6493ec894e50c16"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.27.4"
+version = "0.27.5"
 
 [[Downloads]]
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
@@ -62,9 +62,9 @@ uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [[FiniteDifferences]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Printf", "Random", "Richardson", "StaticArrays"]
-git-tree-sha1 = "18761c465ef2e87d9091c0fefb61f70d532d4cc0"
+git-tree-sha1 = "9a586f04a21e6945f4cbee0d0fb6aebd7b86aa8f"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.16"
+version = "0.12.18"
 
 [[IOCapture]]
 deps = ["Logging", "Random"]
@@ -78,9 +78,9 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
+version = "0.21.2"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -127,9 +127,9 @@ uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "c8abc88faa3f7a3950832ac5d6e690881590d6dc"
+git-tree-sha1 = "438d35d2d95ae2c5e8780b330592b6de8494e779"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.1.0"
+version = "2.0.3"
 
 [[Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -172,9 +172,9 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "1b9a0f17ee0adde9e538227de093467348992397"
+git-tree-sha1 = "3240808c6d463ac46f1c1cd7638375cd22abbccb"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.7"
+version = "1.2.12"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -183,7 +183,8 @@ end
 
 that we do not know an `rrule` for, and we want to check whether the gradients provided by the AD system are correct.
 
-To test gradients the AD system will need to overload `rrule_via_ad` function which wraps the gradients computed by AD.
+To test gradients the AD system you need to provide a `rrule_f` function that acts like calling `rrule` but use AD rather than a defined rule.
+This has the exact same semantics as is required to overload `ChainRulesCore.rrule_via_ad`, thus almost all systems doing so should just overload that, and pass in that and the config, and then trigger `test_rrule(MyADConfig, f, xs; rrule_f = ChainRulesCore.rrule_via_ad)`.
 For some AD systems (e.g. Zygote) this already exists.
 If it does not exist, see [How to write `rrule_via_ad` function](#How-to-write-rrule_via_ad-function) section below.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -183,9 +183,10 @@ end
 
 that we do not know an `rrule` for, and we want to check whether the gradients provided by the AD system are correct.
 
-To test gradients the AD system you need to provide a `rrule_f` function that acts like calling `rrule` but use AD rather than a defined rule.
+To test gradients computed by the AD system you need to provide a `rrule_f` function that acts like calling `rrule` but use AD rather than a defined rule.
 This has the exact same semantics as is required to overload `ChainRulesCore.rrule_via_ad`, thus almost all systems doing so should just overload that, and pass in that and the config, and then trigger `test_rrule(MyADConfig, f, xs; rrule_f = ChainRulesCore.rrule_via_ad)`.
-For some AD systems (e.g. Zygote) this already exists.
+See more info on `rrule_via_ad` and the rule configs in the [ChainRules documentation](https://juliadiff.org/ChainRulesCore.jl/stable/config.html).
+For some AD systems (e.g. Zygote) `rrule_via_ad` already exists.
 If it does not exist, see [How to write `rrule_via_ad` function](#How-to-write-rrule_via_ad-function) section below.
 
 We use the `test_rrule` function to test the gradients using the config used by the AD system

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -183,15 +183,29 @@ end
 
 that we do not know an `rrule` for, and we want to check whether the gradients provided by the AD system are correct.
 
-Firstly, we need to define an `rrule`-like function which wraps the gradients computed by AD.
+To test gradients the AD system will need to overload `rrule_via_ad` function which wraps the gradients computed by AD.
+For some AD systems (e.g. Zygote) this already exists.
+If it does not exist, see "How to write `rrule_via_ad` function" section below.
+
+We use the `test_rrule` function to test the gradients using the config used by the AD system
+```julia
+config = MyAD.CustomRuleConfig()
+test_rrule(config, complicated, 2.3, 6.1; rrule_f=rrule_via_ad)
+```
+by providing the rule config and specifying the `rrule_via_ad` as the `rrule_f` keyword argument.
+
+
+### How to write `rrule_via_ad` function
+
+`rrule_via_ad` will use the AD system to compute gradients and will package them in the `rrule`-like API.
 
 Let's say the AD package uses some custom differential types and does not provide a gradient w.r.t. the function itself.
 In order to make the pullback compatible with the `rrule` API we need to add a `NoTangent()` to represent the differential w.r.t. the function itself.
 We also need to transform the `ChainRules` differential types to the custom types (`cr2custom`) before feeding the `Δ` to the AD-generated pullback, and back to `ChainRules` differential types when returning from the `rrule` (`custom2cr`).
 
 ```julia
-function ad_rrule(f::Function, args...)
-    y, ad_pullback = ADSystem.pullback(f, args...)
+function rrule_via_ad(config::MyAD.CustomRuleConfig, f::Function, args...)
+    y, ad_pullback = MyAD.pullback(f, args...)
     function rrulelike_pullback(Δ)
         diffs = custom2cr(ad_pullback(cr2custom(Δ)))
         return NoTangent(), diffs...
@@ -203,12 +217,6 @@ end
 custom2cr(differential) = ...
 cr2custom(differential) = ...
 ```
-Secondly, we use the `test_rrule` function to test the gradients using the config used by the AD system
-```julia
-config = MyAD.CustomRuleConfig()
-test_rrule(config, complicated, 2.3, 6.1; rrule_f=ad_rrule)
-```
-by specifying the `ad_rrule` as the `rrule_f` keyword argument.
 
 ## Custom finite differencing
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -185,7 +185,7 @@ that we do not know an `rrule` for, and we want to check whether the gradients p
 
 To test gradients the AD system will need to overload `rrule_via_ad` function which wraps the gradients computed by AD.
 For some AD systems (e.g. Zygote) this already exists.
-If it does not exist, see "How to write `rrule_via_ad` function" section below.
+If it does not exist, see [How to write `rrule_via_ad` function](#How-to-write-rrule_via_ad-function) section below.
 
 We use the `test_rrule` function to test the gradients using the config used by the AD system
 ```julia


### PR DESCRIPTION
They were written before `rrule_via_ad` was a thing.