### PR TITLE
add rand_tangent for adjoint sparsecsc

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -8,6 +8,7 @@ using Compat: only
 using FiniteDifferences
 using FiniteDifferences: to_vec
 using LinearAlgebra
+using SparseArrays
 using Random
 using Test
 

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -39,6 +39,9 @@ function rand_tangent(rng::AbstractRNG, x::AbstractArray)
     return _compress_notangent(ProjectTo(x)(rand_tangent(rng, collect(x))))
 end
 
+# adjoint sparse matrix keeps sparse
+rand_tangent(rng::AbstractRNG, x::Adjoint{T, <:SparseMatrixCSC}) where T = rand_tangent(rng, copy(x))
+
 # TODO: arguably ProjectTo should handle this for us for AbstactArrays
 # https://github.com/JuliaDiff/ChainRulesCore.jl/issues/410
 _compress_notangent(::AbstractArray{NoTangent}) = NoTangent()

--- a/test/rand_tangent.jl
+++ b/test/rand_tangent.jl
@@ -88,6 +88,12 @@ struct Bar
             Hermitian(randn(ComplexF64, 1, 1)),
             Hermitian{ComplexF64, Matrix{ComplexF64}},
         ),
+        
+        # SparseArrays
+        (sprand(5, 4, 0.3), SparseMatrixCSC{Float64, Int64}),
+        (sprand(5, 4, 0.3)', SparseMatrixCSC{Float64, Int64}),
+        (sprand(ComplexF64, 5, 4, 0.3), SparseMatrixCSC{ComplexF64, Int64}),
+        (sprand(ComplexF64, 5, 4, 0.3)', SparseMatrixCSC{ComplexF64, Int64}),
     ]
         @test rand_tangent(rng, x) isa T_tangent
         @test rand_tangent(x) isa T_tangent

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,10 +11,10 @@ using Test
 ChainRulesTestUtils.TEST_INFERRED[] = true
 
 @testset "ChainRulesTestUtils.jl" begin
-    # include("meta_testing_tools.jl")
-    # include("iterator.jl")
-    # include("check_result.jl")
-    # include("testers.jl")
-    # include("data_generation.jl")
+    include("meta_testing_tools.jl")
+    include("iterator.jl")
+    include("check_result.jl")
+    include("testers.jl")
+    include("data_generation.jl")
     include("rand_tangent.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using ChainRulesTestUtils
 using ChainRulesTestUtils: rand_tangent
 using FiniteDifferences
 using LinearAlgebra
+using SparseArrays
 using Random
 using Test
 
@@ -10,10 +11,10 @@ using Test
 ChainRulesTestUtils.TEST_INFERRED[] = true
 
 @testset "ChainRulesTestUtils.jl" begin
-    include("meta_testing_tools.jl")
-    include("iterator.jl")
-    include("check_result.jl")
-    include("testers.jl")
-    include("data_generation.jl")
+    # include("meta_testing_tools.jl")
+    # include("iterator.jl")
+    # include("check_result.jl")
+    # include("testers.jl")
+    # include("data_generation.jl")
     include("rand_tangent.jl")
 end


### PR DESCRIPTION
As we know,  the `adjoint` of a sparse matrix should keep the sparsity as well. 
However,  when I test it with CRTU
``` julia
julia> using SparseArrays

julia> using ChainRulesTestUtils

julia> using Random

julia> A = sprand(5,4,0.3)
5×4 SparseMatrixCSC{Float64, Int64} with 8 stored entries:
 0.848189  0.927388   ⋅         ⋅ 
  ⋅        0.390989   ⋅         ⋅ 
 0.843189   ⋅        0.378143   ⋅ 
  ⋅         ⋅         ⋅         ⋅ 
 0.5677     ⋅        0.648571  0.220313

julia> ChainRulesTestUtils.rand_tangent(RandomDevice(), A)
5×4 SparseMatrixCSC{Float64, Int64} with 8 stored entries:
 -2.54   8.71    ⋅     ⋅ 
   ⋅    -7.34    ⋅     ⋅ 
 -8.06    ⋅    -3.51   ⋅ 
   ⋅      ⋅      ⋅     ⋅ 
 -6.43    ⋅     2.71  2.97

julia> ChainRulesTestUtils.rand_tangent(RandomDevice(), A')
4×5 Matrix{Float64}:
 -5.45  -8.14   0.67  -6.1    8.11
 -3.77  -3.21  -4.08   3.44   2.41
 -3.85   5.86   5.01   8.18  -1.88
 -1.7   -7.14  -2.97  -7.59   0.66

julia> B = sprand(ComplexF64, 5, 4, 0.3)
5×4 SparseMatrixCSC{ComplexF64, Int64} with 9 stored entries:
          ⋅            0.487845+0.40227im              ⋅            0.639575+0.848888im
          ⋅                     ⋅             0.995269+0.622351im            ⋅    
 0.752198+0.170268im            ⋅                      ⋅                     ⋅    
          ⋅           0.0758511+0.00334856im  0.971556+0.301835im   0.368199+0.949754im
          ⋅           0.0718783+0.972152im             ⋅           0.0195956+0.953117im

julia> ChainRulesTestUtils.rand_tangent(RandomDevice(), B)
5×4 SparseMatrixCSC{ComplexF64, Int64} with 9 stored entries:
      ⋅       3.7-3.9im       ⋅       0.4+1.6im
      ⋅           ⋅      -4.3-2.9im       ⋅    
 -0.4+8.4im       ⋅           ⋅           ⋅    
      ⋅      -7.2-1.3im  -3.4+0.5im  -5.4+2.6im
      ⋅      -5.8-6.6im       ⋅       6.2-8.3im

julia> ChainRulesTestUtils.rand_tangent(RandomDevice(), B')
4×5 Matrix{ComplexF64}:
  8.5+4.2im   6.4+6.8im  -4.7+6.5im   3.2-3.9im  -5.5+0.7im
  0.8+4.7im   6.2+4.3im   8.8+0.0im   7.3-4.9im  -4.7+3.6im
  4.0-0.3im   5.4-2.9im  -7.9+9.0im  -0.7-0.1im   5.2+1.9im
 -2.2+8.6im  -2.7-7.6im   3.4-7.1im  -3.7-4.2im   7.1-5.2im 
```

It seems `rand_tangent` converts the `adjoint` of sparse matrix into dense arrays. However, thanks to the delicate design of CRTU in `rand_ tangent`, it could be solved by add few lines of code. 