### PR TITLE
Accept that NaN ≈ NaN in test_approx

### DIFF
--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -21,7 +21,7 @@ function test_approx(
     msg="";
     kwargs...,
 )
-    @test_msg msg isapprox(actual, expected; kwargs...)
+    @test_msg msg isapprox(actual, expected; nans=true, kwargs...)
 end
 
 for (T1, T2) in ((AbstractThunk, Any), (AbstractThunk, AbstractThunk), (Any, AbstractThunk))
@@ -62,7 +62,7 @@ The `kwargs` are passed on to `isapprox`
 function _can_pass_early(actual, expected; kwargs...)
     actual == expected && return true
     try
-        return isapprox(actual, expected; kwargs...)
+        return isapprox(actual, expected; nans=true, kwargs...)
     catch err
         # Might MethodError, might DimensionMismatch, might fail for some other reason
         # we don't care, whatever errored it means we can't quit early
@@ -158,7 +158,7 @@ It matters primarily for types that overload `add!!` such as `InplaceableThunk`s
 `acc` is the value that has been accumulated so far.
 `val` is a deriviative, being accumulated into `acc`.
 
-`kwargs` are all passed on to isapprox
+`kwargs` are all passed on to `isapprox`
 """
 function _test_add!!_behaviour(acc, val; kwargs...)
     # Note, we don't test that `acc` is actually mutated because it doesn't have to be


### PR DESCRIPTION
I think this is the behavior we want.
If you get a actual value of NaN and you were expecting a NaN then all seems well.
If both the AD rule and the finite differencing take you here all is well.
(not ok if only one does)