### PR TITLE
Simply rand_tangent(::AbstractArray)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "1.2.3"
+version = "1.3.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ChainRulesCore = "1"
+ChainRulesCore = "1.2"
 Compat = "3"
 FiniteDifferences = "0.12.12"
 julia = "1"

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -22,19 +22,7 @@ end
 # multiply by 9 to give a bigger range of values tested: no so tightly clustered around 0.
 rand_tangent(rng::AbstractRNG, ::BigFloat) = round(big(9 * randn(rng)), digits=5, base=2)
 
-rand_tangent(rng::AbstractRNG, x::Array{<:Any, 0}) = _compress_notangent(fill(rand_tangent(rng, x[])))
-rand_tangent(rng::AbstractRNG, x::Array) = _compress_notangent(rand_tangent.(Ref(rng), x))
-
-# All other AbstractArray's can be handled using the ProjectTo mechanics.
-# and follow the same requirements
-function rand_tangent(rng::AbstractRNG, x::AbstractArray)
-    return _compress_notangent(ProjectTo(x)(rand_tangent(rng, collect(x))))
-end
-
-# TODO: arguably ProjectTo should handle this for us for AbstactArrays
-# https://github.com/JuliaDiff/ChainRulesCore.jl/issues/410
-_compress_notangent(::AbstractArray{NoTangent}) = NoTangent()
-_compress_notangent(x) = x
+rand_tangent(rng::AbstractRNG, x::AbstractArray) = ProjectTo(x)(rand_tangent.(Ref(rng), x))
 
 function rand_tangent(rng::AbstractRNG, x::T) where {T}
     if !isstructtype(T)


### PR DESCRIPTION
1. Since https://github.com/JuliaDiff/ChainRulesCore.jl/pull/424/files  `ProjectTo` handles the collapsing of `AbstractArray{NoTangent}` into `NoTangent()`.
2. Further, `ProjectTo(::Array{Float64,0})(::Float64)` handles converting a scalar into a 0 dimensional array.
3. Finally, there is no need for a `collect` since we can make the broadcasting do that (and that might have been specialized by the container and that is fine)

So we can delete all special cases for generating arrays.

This is a minor bump since we are dropping compat with CRC 1.0 and 1.1
I am pretty sure this has no functional change. Though there might be some edge cases.