### PR TITLE
In checking method table don't nest testsets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "1.5.0"
+version = "1.5.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/global_checks.jl
+++ b/src/global_checks.jl
@@ -22,37 +22,33 @@ was parametric, or `Union` if `Foo` was a type alias for a `Union`)
 function test_method_signature end
 
 function test_method_signature(::typeof(rrule), method::Method)
-    @testset "Sensible Constructors" begin
-        function_type = if method.sig <: Tuple{Any, RuleConfig, Type, Vararg}
-            _parameters(method.sig)[3]
-        elseif method.sig <: Tuple{Any, Type, Vararg}
-            _parameters(method.sig)[2]
-        else
-            nothing
-        end
-        
-        @test_msg(
-            "Bad constructor rrule. `typeof(T)` used rather than `Type{T}`. $method",
-            function_type ∉ (DataType, UnionAll, Union)
-        )
+    function_type = if method.sig <: Tuple{Any, RuleConfig, Type, Vararg}
+        _parameters(method.sig)[3]
+    elseif method.sig <: Tuple{Any, Type, Vararg}
+        _parameters(method.sig)[2]
+    else
+        nothing
     end
+
+    @test_msg(
+        "Bad constructor rrule. `typeof(T)` used rather than `Type{T}`. $method",
+        function_type ∉ (DataType, UnionAll, Union)
+    )
 end
 
 function test_method_signature(::typeof(frule), method::Method)
-    @testset "Sensible Constructors" begin
-        function_type = if method.sig <: Tuple{Any, RuleConfig, Any, Type, Vararg}
-            _parameters(method.sig)[4]
-        elseif method.sig <: Tuple{Any, Any, Type, Vararg}
-            _parameters(method.sig)[3]
-        else
-            nothing
-        end
-
-        @test_msg(
-            "Bad constructor frule. `typeof(T)` used rather than `Type{T}`. $method",
-            function_type ∉ (DataType, UnionAll, Union)
-        )
+    function_type = if method.sig <: Tuple{Any, RuleConfig, Any, Type, Vararg}
+        _parameters(method.sig)[4]
+    elseif method.sig <: Tuple{Any, Any, Type, Vararg}
+        _parameters(method.sig)[3]
+    else
+        nothing
     end
+
+    @test_msg(
+        "Bad constructor frule. `typeof(T)` used rather than `Type{T}`. $method",
+        function_type ∉ (DataType, UnionAll, Union)
+    )
 end
 
 """


### PR DESCRIPTION
Follow up to #228  now that i tried it for real.

I forgot all passing testsets  were show if in same testset as failing one.
Which on real use cases is 1459

```
Test Summary:             | Pass  Fail  Total
ChainRules                | 1529     1   1530
  test_helpers.jl         |   69           69
  Sensible Constructors   | 1460     1   1461
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    Sensible Constructors |    1            1
    ...
    ```