### PR TITLE
Remove test_approx ambig between Thunk and Tangent

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "1.6.0"
+version = "1.7.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/check_result.jl
+++ b/src/check_result.jl
@@ -123,6 +123,10 @@ function test_approx(actual::Tangent{P,T}, expected, msg=""; kwargs...) where {T
 end
 test_approx(x, y::Tangent, msg=""; kwargs...) = test_approx(y, x, msg; kwargs...)
 
+function test_approx(actual::Tangent, expected::AbstractThunk, msg=""; kwargs...)
+    return test_approx(actual, unthunk(expected), msg; kwargs...)
+end
+
 # This catches comparisons of Tangents and Tuples/NamedTuple
 # and gives an error message complaining about that. the `@test` will definitely fail
 const LegacyZygoteCompTypes = Union{Tuple,NamedTuple}

--- a/test/check_result.jl
+++ b/test/check_result.jl
@@ -75,6 +75,13 @@ end
                 FakeNaturalDiffWithIsApprox(1.4),
                 Tangent{FakeNaturalDiffWithIsApprox}(; x=1.4),
             )
+
+            # ambig with CRC after:
+            # https://github.com/JuliaDiff/ChainRulesCore.jl/pull/524#issuecomment-1074037647
+            test_approx(
+                Tangent{Tuple{Float64,Float64}}(1.0, 2.0),
+                @thunk(Tangent{Tuple{Float64,Float64}}(1.0, 2.0)),
+            )
         end
         @testset "negative case" begin
             @test fails(() -> test_approx(1.0, 2.0))

--- a/test/check_result.jl
+++ b/test/check_result.jl
@@ -97,6 +97,14 @@ end
             @test fails(() -> test_approx(@thunk(10 * [[1.0], [2.0]]), [[1.0], [2.0]]))
 
             @test fails(() -> test_approx(@not_implemented("a"), @not_implemented("b")))
+
+            # should fail, not ambig error
+            @test fails() do 
+                test_approx(
+                    Tangent{Tuple{Float64,Float64}}(1.0, 2.0),
+                    @thunk(Tangent{Tuple{Float64,Float64}}(2.0, 2.0)),
+                )
+            end
         end
         @testset "type negative" begin
             @test fails() do  # these have different primals so should not be equal


### PR DESCRIPTION
Should unblock
https://github.com/JuliaDiff/ChainRulesCore.jl/pull/524#issuecomment-1074037647

Even if that PR isn't merged this is technically needed to get a good failure rather than a error when not matching