### PR TITLE
Pass keyword arguments to `test_approx` when checking chunks

### DIFF
--- a/src/testers.jl
+++ b/src/testers.jl
@@ -227,7 +227,7 @@ function test_rrule(
         end
 
         if check_thunked_output_tangent
-            test_approx(ad_cotangents, pullback(@thunk(ȳ)), "pulling back a thunk:")
+            test_approx(ad_cotangents, pullback(@thunk(ȳ)), "pulling back a thunk:"; isapprox_kwargs...)
             check_inferred && _test_inferred(pullback, @thunk(ȳ))
         end
     end  # top-level testset


### PR DESCRIPTION
Just ran into a test issue where I need `nans=true` as keyword argument to `isapprox` (cf https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/220) but it was not forwarded when testing pullbacks with chunks.