### PR TITLE
Allow editing the testset name

### DIFF
--- a/src/testers.jl
+++ b/src/testers.jl
@@ -13,6 +13,7 @@ at input point `z` to confirm that there are correct `frule` and `rrule`s provid
 - `fkwargs` are passed to `f` as keyword arguments.
 - If `check_inferred=true`, then the inferrability (type-stability) of the `frule` and `rrule` are checked.
 - `testset_name`: if provided, the name of the testset used to wrap the tests.
+  Otherwise it is determined from the function and argument types.
 - All remaining keyword arguments are passed to `isapprox`.
 """
 function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(), check_inferred=true, testset_name=nothing, kwargs...)
@@ -91,7 +92,8 @@ end
    - If `check_inferred=true`, then the inferrability (type-stability) of the `frule` is checked,
      as long as `f` is itself inferrable.
    - `fkwargs` are passed to `f` as keyword arguments.
-   - `testset_name`: if provided, the name of the testset used to wrap the tests.
+- `testset_name`: if provided, the name of the testset used to wrap the tests.
+  Otherwise it is determined from the function and argument types.
    - All remaining keyword arguments are passed to `isapprox`.
 """
 function test_frule(args...; kwargs...)
@@ -168,7 +170,8 @@ end
  - If `check_inferred=true`, then the inferrability (type-stability) of the `rrule` is checked
    — if `f` is itself inferrable — along with the inferrability of the pullback it returns.
  - `fkwargs` are passed to `f` as keyword arguments.
- - `testset_name`: if provided, the name of the testset used to wrap the tests.
+- `testset_name`: if provided, the name of the testset used to wrap the tests.
+  Otherwise it is determined from the function and argument types.
  - All remaining keyword arguments are passed to `isapprox`.
 """
 function test_rrule(args...; kwargs...)

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -196,7 +196,7 @@ function test_rrule(
     # and define helper closure over fkwargs
     call(f, xs...) = f(xs...; fkwargs...)
 
-    @testset "test_rrule: $f on $(_string_typeof(args))" begin
+    @testset "$(testset_name)" begin
 
         # Check correctness of evaluation.
         primals_and_tangents = auto_primal_and_tangent.((f, args...))

--- a/src/testers.jl
+++ b/src/testers.jl
@@ -12,14 +12,16 @@ at input point `z` to confirm that there are correct `frule` and `rrule`s provid
 - `fdm`: the finite differencing method to use.
 - `fkwargs` are passed to `f` as keyword arguments.
 - If `check_inferred=true`, then the inferrability (type-stability) of the `frule` and `rrule` are checked.
+- `testset_name`: if provided, the name of the testset used to wrap the tests.
 - All remaining keyword arguments are passed to `isapprox`.
 """
-function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(), check_inferred=true, kwargs...)
+function test_scalar(f, z; rtol=1e-9, atol=1e-9, fdm=_fdm, fkwargs=NamedTuple(), check_inferred=true, testset_name=nothing, kwargs...)
     # To simplify some of the calls we make later lets group the kwargs for reuse
     rule_test_kwargs = (; rtol=rtol, atol=atol, fdm=fdm, fkwargs=fkwargs, check_inferred=check_inferred, kwargs...)
     isapprox_kwargs = (; rtol=rtol, atol=atol, kwargs...)
+    testset_name = isnothing(testset_name) ? "test_scalar: $f at $z" : testset_name
 
-    @testset "test_scalar: $f at $z" begin
+    @testset "$(testset_name)" begin
         # z = x + im * y
         # Ω = u(x, y) + im * v(x, y)
         Ω = f(z; fkwargs...)
@@ -89,6 +91,7 @@ end
    - If `check_inferred=true`, then the inferrability (type-stability) of the `frule` is checked,
      as long as `f` is itself inferrable.
    - `fkwargs` are passed to `f` as keyword arguments.
+   - `testset_name`: if provided, the name of the testset used to wrap the tests.
    - All remaining keyword arguments are passed to `isapprox`.
 """
 function test_frule(args...; kwargs...)
@@ -106,15 +109,16 @@ function test_frule(
     fkwargs::NamedTuple=NamedTuple(),
     rtol::Real=1e-9,
     atol::Real=1e-9,
+    testset_name=nothing,
     kwargs...,
 )
     # To simplify some of the calls we make later lets group the kwargs for reuse
     isapprox_kwargs = (; rtol=rtol, atol=atol, kwargs...)
-
+    testset_name = isnothing(testset_name) ? "test_frule: $f on $(_string_typeof(args))" : testset_name
     # and define a helper closure
     call_on_copy(f, xs...) = deepcopy(f)(deepcopy(xs)...; deepcopy(fkwargs)...)
 
-    @testset "test_frule: $f on $(_string_typeof(args))" begin
+    @testset "$(testset_name)" begin
 
         primals_and_tangents = auto_primal_and_tangent.((f, args...))
         primals = primal.(primals_and_tangents)
@@ -164,6 +168,7 @@ end
  - If `check_inferred=true`, then the inferrability (type-stability) of the `rrule` is checked
    — if `f` is itself inferrable — along with the inferrability of the pullback it returns.
  - `fkwargs` are passed to `f` as keyword arguments.
+ - `testset_name`: if provided, the name of the testset used to wrap the tests.
  - All remaining keyword arguments are passed to `isapprox`.
 """
 function test_rrule(args...; kwargs...)
@@ -182,11 +187,12 @@ function test_rrule(
     fkwargs::NamedTuple=NamedTuple(),
     rtol::Real=1e-9,
     atol::Real=1e-9,
+    testset_name=nothing,
     kwargs...,
 )
     # To simplify some of the calls we make later lets group the kwargs for reuse
     isapprox_kwargs = (; rtol=rtol, atol=atol, kwargs...)
-
+    testset_name = isnothing(testset_name) ? "test_rrule: $f on $(_string_typeof(args))" : testset_name
     # and define helper closure over fkwargs
     call(f, xs...) = f(xs...; fkwargs...)
 

--- a/test/testers.jl
+++ b/test/testers.jl
@@ -725,4 +725,15 @@ end
         test_frule(f_vec_of_tuples, x_tuples)
         test_rrule(f_vec_of_tuples, x_tuples)
     end
+    @testset "check passing of testset_name kwarg" begin
+        name = "my test name"
+        double(x) = 2x
+        @scalar_rule(double(x), 2)
+        x = test_scalar(double, 2.1; testset_name=name)
+        @test x.description == name
+        x = test_frule(identity, 1.0; testset_name=name)
+        @test x.description == name
+        x = test_rrule(identity, 1.0; testset_name=name)
+        @test x.description == name
+    end
 end


### PR DESCRIPTION
Solves #272 

Add a keyword argument "`testset_name`" to `test_scalar`, `test_frule` and `test_rrule` to allow replacing the default name.
It still stays an opt-in option and is mostly useful when `f` is anonymous and its naming is too large to be displayed correctly.