### PR TITLE
Monkey patch Test.scrub_backtrace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesTestUtils"
 uuid = "cdddcdb0-9152-4a09-a978-84456f9df70a"
-version = "1.11.0"
+version = "1.12.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
@@ -15,6 +16,7 @@ ChainRulesCore = "1.11.2"
 Compat = "3, 4"
 FiniteDifferences = "0.12.12"
 MetaTesting = "0.1"
+Suppressor = "0.2.6"
 julia = "1"
 
 [extras]

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -23,6 +23,8 @@ function __init__()
     # Try to disable backtrace scrubbing so that full failures are shown
     try
         isdefined(Test, :scrub_backtrace) || error("Test.scrub_backtrace not defined")
+        # depending on julia version or one or the other of these will be hit
+        @eval Test scrub_backtrace(bt,) = bt  # make it do nothing
         @eval Test scrub_backtrace(bt, file_ts, file_t) = bt  # make it do nothing
     catch err
         @warn "Failed to monkey=patch scrub_backtrace. Code is functional but stacktraces may be less useful" exception=(err, catch_backtrace())

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -10,6 +10,7 @@ using FiniteDifferences: to_vec
 using LinearAlgebra
 using Random
 using Test
+using Suppressor
 
 export TestIterator
 export test_approx, test_scalar, test_frule, test_rrule, generate_well_conditioned_matrix
@@ -23,9 +24,11 @@ function __init__()
     # Try to disable backtrace scrubbing so that full failures are shown
     try
         isdefined(Test, :scrub_backtrace) || error("Test.scrub_backtrace not defined")
-        # depending on julia version or one or the other of these will be hit
-        @eval Test scrub_backtrace(bt,) = bt  # make it do nothing
-        @eval Test scrub_backtrace(bt, file_ts, file_t) = bt  # make it do nothing
+        @suppress begin  # mute warning about monkey-patching
+            # depending on julia version or one or the other of these will be hit
+            @eval Test scrub_backtrace(bt,) = bt  # make it do nothing
+            @eval Test scrub_backtrace(bt, file_ts, file_t) = bt  # make it do nothing
+        end
     catch err
         @warn "Failed to monkey=patch scrub_backtrace. Code is functional but stacktraces may be less useful" exception=(err, catch_backtrace())
     end

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -17,7 +17,17 @@ export ⊢, rand_tangent
 export @maybe_inferred
 export test_method_tables
 
-__init__() = init_test_inferred_setting!()
+function __init__()
+    init_test_inferred_setting!()
+
+    # Try to disable backtrace scrubbing so that full failures are shown
+    try
+        isdefined(Test, :scrub_backtrace) || error("Test.scrub_backtrace not defined")
+        @eval Test scrub_backtrace(bt, file_ts, file_t) = bt  # make it do nothing
+    catch err
+        @warn "Failed to monkey=patch scrub_backtrace. Code is functional but stacktraces may be less useful" exception=(err, catch_backtrace())
+    end
+end
 
 include("global_config.jl")
 
@@ -36,3 +46,4 @@ include("testers.jl")
 include("deprecated.jl")
 include("global_checks.jl")
 end # module
+

--- a/src/ChainRulesTestUtils.jl
+++ b/src/ChainRulesTestUtils.jl
@@ -30,7 +30,7 @@ function __init__()
             @eval Test scrub_backtrace(bt, file_ts, file_t) = bt  # make it do nothing
         end
     catch err
-        @warn "Failed to monkey=patch scrub_backtrace. Code is functional but stacktraces may be less useful" exception=(err, catch_backtrace())
+        @warn "Failed to monkey-patch scrub_backtrace. Code is functional but stacktraces may be less useful" exception=(err, catch_backtrace())
     end
 end
 


### PR DESCRIPTION
Problem is 
the `@test` macro is that it scrubs backtraces to remove stuff from deeper down the stack than the location of the macro, and since `test_rrule` etc use those macros directly the back trace no longer includes the call site in the users tests.

Simple solution is to just stop scrubbing backtraces entirely.
If people like this we could follow up with something more sophisticated.
But lets have that as a seperate PR
 
This does mean whenever tests are run this warning will show.

```
     Testing Running tests...
WARNING: Method definition scrub_backtrace(Any, Any, Any) in module Test at /home/oxinabox/dist/julia-cedar/vanilla/latest/share/julia/stdlib/v1.11/Test/src/Test.jl:89 overwritten at /home/oxinabox/JuliaEnvs/ChainRulesTestUtils.jl/src/ChainRulesTestUtils.jl:26.
Testing ChainRules.jl
```
Could surpress that though.

