### PR TITLE
ci: update github actions & fix UndefVarError

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,22 +27,10 @@ jobs:
           - os: macOS-latest
             arch: x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v2
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-${{ matrix.arch }}-test-
-            ${{ runner.os }}-${{ matrix.arch }}-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,19 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.0"  # LTS
-          - "1"    # Latest Release
+          - "lts"
+          - "1"  # Latest Release
         os:
           - ubuntu-latest
-          - macOS-latest
+          - macOS-latest  # Apple silicon
           - windows-latest
-        arch:
-          - x86
-          - x64
-        exclude:
-          # 32-bit Julia binaries are not available on macOS
-          - os: macOS-latest
-            arch: x86
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -10,11 +10,11 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.6'
-      - uses: julia-actions/julia-docdeploy@latest
+          version: '1.10'
+      - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/JuliaNightly.yml
+++ b/.github/workflows/JuliaNightly.yml
@@ -7,27 +7,22 @@ on:
     branches: [master]
     tags: ["*"]
   pull_request:
+
 jobs:
   test:
     name: Julia Nightly - Ubuntu - x64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: nightly
-          arch: x64
-      - uses: actions/cache@v2
-        env:
-          cache-name: julia-nightly-cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ env.cache-name }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
+        continue-on-error: true
         with:
+          token: ${{ secrets.CODECOV_TOKEN }} # required
           file: lcov.info

--- a/.github/workflows/fix_doctests.yml
+++ b/.github/workflows/fix_doctests.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        julia-version: [1.6]
+        julia-version: '1.10'
     steps:
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
-      - uses: actions/checkout@v1
       - name: Fix doctests
         shell: julia --project=docs/ {0}
         run: |

--- a/src/output_control.jl
+++ b/src/output_control.jl
@@ -1,6 +1,12 @@
 # Test.get_test_result generates code that uses the following so we must import them
 using Test: Returned, Threw, eval_test
 
+@static if VERSION >= v"1.13.0-DEV.300"
+    # https://github.com/JuliaLang/julia/commit/d934b032ea5bf63b353371ad285605128c735873
+    # used by `Test.do_test` in `macro test_msg`
+    using Test: eval_test_comparison
+end
+
 "A cunning hack to carry extra message along with the original expression in a test"
 struct ExprAndMsg
     ex

--- a/src/output_control.jl
+++ b/src/output_control.jl
@@ -4,7 +4,7 @@ using Test: Returned, Threw, eval_test
 @static if VERSION >= v"1.13.0-DEV.300"
     # https://github.com/JuliaLang/julia/commit/d934b032ea5bf63b353371ad285605128c735873
     # used by `Test.do_test` in `macro test_msg`
-    using Test: eval_test_comparison
+    using Test: eval_test_comparison, eval_test_function
 end
 
 "A cunning hack to carry extra message along with the original expression in a test"


### PR DESCRIPTION
ChainRulesTestUtils.jl not work with julia nightly

https://github.com/JuliaMath/AbstractFFTs.jl/actions/runs/14931159549/job/41947508400?pr=139#step:6:160
```
test_frule: fftshift on Vector{Float64},: Error During Test at /home/runner/.julia/packages/ChainRulesTestUtils/Ko1Wr/src/testers.jl:135
  Test threw exception
  Expression: 
  UndefVarError: `eval_test_comparison` not defined in `ChainRulesTestUtils`
  Suggestion: check for spelling errors or missing imports.
  Stacktrace:
    [1] macro expansion
      @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.13/Test/src/Test.jl:727 [inlined]
    [2] macro expansion
      @ ~/.julia/packages/ChainRulesTestUtils/Ko1Wr/src/testers.jl:135 [inlined]
    [3] macro expansion
      @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.13/Test/src/Test.jl:1833 [inlined]
    [4] test_frule(::RuleConfig, ::Any, ::Any, ::Vararg{Any}; output_tangent::Any, fdm::Any, frule_f::Any, check_inferred::Bool, fkwargs::NamedTuple, rtol::Real, atol::Real, testset_name::Any, kwargs...)
      @ ChainRulesTestUtils ~/.julia/packages/ChainRulesTestUtils/Ko1Wr/src/testers.jl:125
    [5] test_frule
      @ ~/.julia/packages/ChainRulesTestUtils/Ko1Wr/src/testers.jl:103 [inlined]
    [6] #test_frule#54
      @ ~/.julia/packages/ChainRulesTestUtils/Ko1Wr/src/testers.jl:100 [inlined]
    [7] test_frule(::Any, ::Any, ::Any)
      @ ChainRulesTestUtils ~/.julia/packages/ChainRulesTestUtils/Ko1Wr/src/testers.jl:99
    [8] top-level scope
      @ ~/work/AbstractFFTs.jl/AbstractFFTs.jl/test/runtests.jl:197
    [9] macro expansion
      @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.13/Test/src/Test.jl:[183](https://github.com/JuliaMath/AbstractFFTs.jl/actions/runs/14931159549/job/41947508400?pr=139#step:6:186)3 [inlined]
   [10] macro expansion
      @ ~/work/AbstractFFTs.jl/AbstractFFTs.jl/test/runtests.jl:198 [inlined]
   [11] macro expansion
      @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.13/Test/src/Test.jl:1833 [inlined]
   [12] macro expansion
      @ ~/work/AbstractFFTs.jl/AbstractFFTs.jl/test/runtests.jl:207 [inlined]
   [13] include(mapexpr::Function, mod::Module, _path::String)
      @ Base ./Base.jl:310
   [14] top-level scope
      @ none:6
   [15] eval(m::Module, e::Any)
      @ Core ./boot.jl:489
   [16] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:297
   [17] _start()
      @ Base ./client.jl:564
```