### PR TITLE
Fix imports of Test functions on versions >1.12

### DIFF
--- a/src/output_control.jl
+++ b/src/output_control.jl
@@ -1,5 +1,12 @@
 # Test.get_test_result generates code that uses the following so we must import them
-using Test: Returned, Threw, eval_test
+using Test: Returned, Threw
+
+# depends on the version
+@static if VERSION ≤ v"1.12"
+    using Test: eval_test
+else
+    using Test: eval_test_comparison, eval_test_function
+end
 
 "A cunning hack to carry extra message along with the original expression in a test"
 struct ExprAndMsg


### PR DESCRIPTION
After https://github.com/JuliaLang/julia/pull/57839, the `Test.eval_test` function no longer exists and is split into `eval_test_comparison` and `eval_test_function`. This fixes the imports, such that CI tests on Julia nightly can run.

It might be better to not depend on internals in the long run, but I don't currently have the time to fix this.